### PR TITLE
Deck 상세 화면과 Today 연결

### DIFF
--- a/app/lib/app_root.dart
+++ b/app/lib/app_root.dart
@@ -41,6 +41,7 @@ class _AppRootState extends State<AppRoot> {
           ..clear()
           ..addAll(cards);
         _isLoading = false;
+        _stats = SessionStats(target: 30, completed: 0, known: 0, unsure: 0, again: 0, done: false);
       });
     } catch (error) {
       if (!mounted) return;
@@ -137,7 +138,11 @@ class _AppRootState extends State<AppRoot> {
         cards: _cards,
         onStatsChanged: (s) => setState(() => _stats = s),
       ),
-      DecksScreen(totalCards: _cards.length),
+      DecksScreen(
+        totalCards: _cards.length,
+        customCards: _cards.where((card) => card.level == 'custom').length,
+        onStartToday: () => setState(() => _currentIndex = 0),
+      ),
       AddScreen(
         key: const ValueKey('add-screen'),
         onAddCard: _addCard,

--- a/app/lib/screens/decks_screen.dart
+++ b/app/lib/screens/decks_screen.dart
@@ -3,9 +3,16 @@ import 'package:flutter/material.dart';
 import '../widgets/review_note_card.dart';
 
 class DecksScreen extends StatelessWidget {
-  const DecksScreen({super.key, required this.totalCards});
+  const DecksScreen({
+    super.key,
+    required this.totalCards,
+    required this.customCards,
+    required this.onStartToday,
+  });
 
   final int totalCards;
+  final int customCards;
+  final VoidCallback onStartToday;
 
   @override
   Widget build(BuildContext context) {
@@ -26,9 +33,83 @@ class DecksScreen extends StatelessWidget {
             title: const Text('중2 초급 영어 120'),
             subtitle: Text('카드 $totalCards개 · 다음 복습: 오늘 · 상태: 진행 중'),
             trailing: const Icon(Icons.chevron_right),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => DeckDetailScreen(
+                  totalCards: totalCards,
+                  customCards: customCards,
+                  onStartToday: () {
+                    Navigator.of(context).pop();
+                    onStartToday();
+                  },
+                ),
+              ),
+            ),
           ),
         ),
       ],
+    );
+  }
+}
+
+class DeckDetailScreen extends StatelessWidget {
+  const DeckDetailScreen({
+    super.key,
+    required this.totalCards,
+    required this.customCards,
+    required this.onStartToday,
+  });
+
+  final int totalCards;
+  final int customCards;
+  final VoidCallback onStartToday;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Deck Detail')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text('중2 초급 영어 120', style: Theme.of(context).textTheme.headlineSmall),
+          const SizedBox(height: 8),
+          Text(
+            '오늘 복습 우선 덱 · 바로 Today로 돌아가 학습을 시작할 수 있습니다.',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          Card(
+            child: ListTile(
+              title: const Text('카드 수'),
+              subtitle: Text('$totalCards개'),
+            ),
+          ),
+          Card(
+            child: ListTile(
+              title: const Text('직접 추가 카드'),
+              subtitle: Text('$customCards개'),
+            ),
+          ),
+          const Card(
+            child: ListTile(
+              title: Text('다음 복습'),
+              subtitle: Text('오늘'),
+            ),
+          ),
+          const Card(
+            child: ListTile(
+              title: Text('일일 목표'),
+              subtitle: Text('빠른 30카드'),
+            ),
+          ),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: onStartToday,
+            icon: const Icon(Icons.play_arrow),
+            label: const Text('학습 시작'),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -85,4 +85,33 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.textContaining('카드 121개'), findsOneWidget);
   });
+
+  testWidgets('Deck detail can start Today and reflects custom card count', (WidgetTester tester) async {
+    await tester.pumpWidget(const RepeatoApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Add').last);
+    await tester.pumpAndSettle();
+
+    final fields = find.byType(TextFormField);
+    await tester.enterText(fields.at(0), 'portable');
+    await tester.enterText(fields.at(1), '휴대용의');
+    await tester.enterText(fields.at(2), '여행 영어');
+    await tester.tap(find.text('카드 저장'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Decks').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('중2 초급 영어 120'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Deck Detail'), findsOneWidget);
+    expect(find.text('121개'), findsOneWidget);
+    expect(find.text('1개'), findsOneWidget);
+
+    await tester.tap(find.text('학습 시작'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('진행: 0 /'), findsOneWidget);
+  });
 }

--- a/doc/context-inbox.md
+++ b/doc/context-inbox.md
@@ -17,16 +17,16 @@
 
 ## Active
 - 날짜: 2026-03-08
-- 작업 주제: Add 직접 입력 MVP 구현 및 검증
+- 작업 주제: Deck 상세 화면과 Today 연결 구현
 - 임시 컨텍스트:
-  - GitHub 이슈 `#1 Add direct input MVP` 생성 완료
-  - 작업 브랜치 `feat/1-add-direct-input-mvp` 생성 완료
-  - PR `#2 Add direct input MVP and workflow coverage gate` 생성 완료
-  - Add 탭은 직접 입력 폼, 저장 완료 CTA, Today 이동, Decks 반영까지 로컬 구현 완료
+  - GitHub 이슈 `#3 Connect Deck detail to Today` 생성 완료
+  - 작업 브랜치 `feat/3-decks-today-link` 생성 완료
+  - Deck 상세 화면 진입과 `학습 시작` CTA를 Today 탭 이동으로 연결
+  - Add로 늘어난 카드 수가 Deck 상세 카드 수/직접 추가 카드 수에 반영됨
   - `flutter analyze` 통과
-  - `flutter test --coverage` 통과, line coverage 84.31%
+  - `flutter test --coverage` 통과, line coverage 85.59%
 - 검증 필요:
-  - Deck 상세 화면과 Today 연결 구현을 다음 작업으로 바로 이어갈지
-  - PR `#2` 수동 QA 체크를 언제 수행할지
+  - Deck 상세에서 다음 복습/목표 외에 어떤 정보가 더 필요한지
+  - 다음 작업을 SQLite 설계 코드화와 Deck 상태 모델 중 무엇으로 둘지
 - 메모:
-  - coverage 70% 기준은 현재 작업에서 충족됨
+  - coverage 70% 기준은 현재 작업에서도 충족됨

--- a/doc/context-log.md
+++ b/doc/context-log.md
@@ -258,6 +258,18 @@
 - 후속 작업: PR `#2` 기준 수동 QA를 수행하고, 다음 작업은 별도 이슈/브랜치로 `Deck 상세 화면과 Today 연결`을 시작한다.
 
 - 날짜: 2026-03-08
+- 결정: `Deck 상세 화면과 Today 연결` 작업은 GitHub 이슈 `#3`과 브랜치 `feat/3-decks-today-link`에서 진행하고, 범위는 덱 상세 진입/요약 정보/`학습 시작` CTA 연결로 제한한다.
+- 근거: 다음 우선순위 작업을 기존 workflow에 맞춰 즉시 시작해야 했고, 현재 다중 덱/SQLite 상태 모델이 아직 없으므로 단일 대표 덱 기준의 상세 화면 연결이 가장 작은 검증 가능 단위이기 때문이다.
+- 영향 범위: `app/lib/app_root.dart`, `app/lib/screens/decks_screen.dart`, `app/test/widget_test.dart`, GitHub issue `#3`.
+- 후속 작업: PR 단계에서 Deck 상세 노출 정보와 Today 이동 회귀 범위를 본문에 기록한다.
+
+- 날짜: 2026-03-08
+- 결정: 이번 `Deck 상세 화면과 Today 연결` 검증 결과는 `flutter analyze` 통과, `flutter test --coverage` 통과, line coverage `85.59%`로 기록한다.
+- 근거: 새 workflow 규칙에 따라 모든 개발 반복에서 테스트 라인 커버리지 70% 이상 유지 여부를 실제 수치로 남겨야 하기 때문이다.
+- 영향 범위: QA 게이트, PR 본문 커버리지 기록, 다음 개발 이슈의 coverage plan 누적 방식.
+- 후속 작업: 다음 작업에서도 동일한 coverage 계산 방식(`coverage/lcov.info`)을 사용한다.
+
+- 날짜: 2026-03-08
 - 결정: 개발 작업은 GitHub 이슈, 이슈 번호 포함 브랜치, PR, QA, 머지 순서를 강제하고, 구현 전에는 Development Lead 포함 3인 검토를 필수로 둔다.
 - 근거: 사용자 요청이 개발 절차의 추적성과 역할 분담을 강하게 요구했고, 작업 누락과 범위 드리프트를 줄이려면 GitHub tracking을 강제해야 하기 때문이다.
 - 영향 범위: `AGENTS.md`, `.github/ISSUE_TEMPLATE/feature-task.yml`, `.github/PULL_REQUEST_TEMPLATE.md`, 향후 개발 작업 시작 방식.

--- a/doc/next-actions.md
+++ b/doc/next-actions.md
@@ -1,8 +1,8 @@
 # Next Actions
 
 ## Priority Queue
-1. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` Deck 상세 화면과 Today 연결 구현
-2. [ ] (P1) `#STAGE-C #TASK-DATA #TASK-APP #ORG-ARCH #ORG-DATA #ORG-FE` Flutter 로컬 SQLite 저장 계층과 도메인 모델 설계안을 코드 구조로 내리기 (`doc/work/repeato-local-first-architecture-v1.md`)
+1. [ ] (P1) `#STAGE-C #TASK-DATA #TASK-APP #ORG-ARCH #ORG-DATA #ORG-FE` Flutter 로컬 SQLite 저장 계층과 도메인 모델 설계안을 코드 구조로 내리기 (`doc/work/repeato-local-first-architecture-v1.md`)
+2. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` Deck 상태 모델 확장(진행 중/일시중지/완료)과 상세 정보 고도화
 3. [ ] (P1) `#STAGE-C #TASK-WORKFLOW #ORG-WF-ARCH #ORG-WF-LIB #ORG-WF-AUTO #ORG-PM` workflow 조직 세션 기준 문서 유지 및 coverage 70% 운영 규칙을 다음 개발 이슈/PR에 계속 적용
 4. [ ] (P1) `#STAGE-B #TASK-LEARNING #TASK-TAB #ORG-PM #ORG-DESIGN #ORG-EDU #ORG-COG` 카드 템플릿/정답 판정/세션 규칙과 공통 상태 키 확정 (`doc/plan-checklist.md` + `doc/work/repeato-cross-tab-conflict-review-v1.md`)
 5. [ ] (P1) `#STAGE-C #TASK-DATA #ORG-PM #ORG-DATA #ORG-ARCH` KPI/이벤트 스키마 확정 후 `Insights` 구현 착수 (`doc/work/repeato-insights-tab-spec-v1.md`)
@@ -14,6 +14,11 @@
 - Flutter line coverage 측정/기록 방식은 다음 개발 이슈에서 실제 명령과 보고 포맷을 고정할 필요가 있음
 
 ## Done in This Iteration
+- Deck 상세 화면 진입 및 `학습 시작` CTA로 Today 이동 연결
+- Add로 증가한 카드 수를 Deck 상세에 반영
+- `flutter analyze` 통과
+- `flutter test --coverage` 통과
+- 라인 커버리지 `85.59%` 확인
 - Add 직접 입력 MVP 이슈 생성(`#1`) 및 브랜치 생성(`feat/1-add-direct-input-mvp`)
 - Add 직접 입력 폼 구현(앞면/뒷면/덱)
 - 저장 후 CTA 구현(`계속 추가`, `Today로 이동`)


### PR DESCRIPTION
## 연결 이슈
- Closes #3

## 요약
- Decks 목록 카드 탭 시 Deck 상세 화면으로 진입하도록 구현했습니다
- Deck 상세 화면에 카드 수, 직접 추가 카드 수, 다음 복습, 일일 목표를 표시했습니다
- `학습 시작` CTA가 실제 Today 탭으로 이동하도록 연결했습니다
- Add로 늘어난 카드 수가 Deck 상세 정보에 반영되도록 연결했습니다

## 리뷰 계획
- Development Lead: Deck 상세 진입과 Today 연결 범위 검토
- Feature Engineer: Deck 상세 UI와 CTA 동작 검토
- Integration Engineer: Add 이후 Deck 상세 수치 반영과 Today 회귀 검토

## 테스트
- [x] `flutter test --coverage`
- [x] `flutter analyze`
- [x] coverage >= 70%
- [ ] manual QA

## 커버리지
- 현재 line coverage: `85.59%`
- 70% 미만일 때 사유: 해당 없음
- 후속 계획 / 담당: 다음 SQLite/Deck 상태 모델 작업에서도 동일 포맷 유지

## 사용자 영향
- 사용자가 Decks에서 상세 정보를 확인하고 바로 Today 학습으로 이동할 수 있습니다
- Add로 추가한 카드 수가 Deck 상세에도 즉시 반영됩니다

## QA 포인트
- Deck 카드 탭 시 상세 화면 진입
- `학습 시작` CTA의 Today 탭 이동
- Deck 상세 카드 수 / 직접 추가 카드 수 반영
- 기존 Today / Insights 흐름 회귀 여부

## PM 의사결정 필요 항목
- 없음