### PR TITLE
Insights KPI 대시보드와 Today 재진입 CTA

### DIFF
--- a/app/lib/app_root.dart
+++ b/app/lib/app_root.dart
@@ -148,12 +148,20 @@ class _AppRootState extends State<AppRoot> {
         onAddCard: _addCard,
         onNavigateToday: () => setState(() => _currentIndex = 0),
       ),
-      InsightsScreen(stats: _stats),
+      InsightsScreen(
+        stats: _stats,
+        onStartToday: () => setState(() => _currentIndex = 0),
+      ),
       const ProfileScreen(),
     ];
 
     return Scaffold(
-      body: SafeArea(child: screens[_currentIndex]),
+      body: SafeArea(
+        child: IndexedStack(
+          index: _currentIndex,
+          children: screens,
+        ),
+      ),
       bottomNavigationBar: NavigationBar(
         selectedIndex: _currentIndex,
         onDestinationSelected: (i) => setState(() => _currentIndex = i),

--- a/app/lib/screens/insights_screen.dart
+++ b/app/lib/screens/insights_screen.dart
@@ -4,14 +4,25 @@ import '../models/session_stats.dart';
 import '../widgets/review_note_card.dart';
 
 class InsightsScreen extends StatelessWidget {
-  const InsightsScreen({super.key, required this.stats});
+  const InsightsScreen({
+    super.key,
+    required this.stats,
+    required this.onStartToday,
+  });
 
   final SessionStats stats;
+  final VoidCallback onStartToday;
 
   @override
   Widget build(BuildContext context) {
     final solved = stats.known + stats.unsure + stats.again;
     final accuracy = solved == 0 ? 0 : ((stats.known / solved) * 100).round();
+    final completionRate = stats.target == 0 ? 0 : ((stats.completed / stats.target) * 100).round();
+    final todayStatus = stats.done
+        ? '오늘 목표 달성'
+        : solved == 0
+            ? '아직 시작 전'
+            : '진행 중';
 
     return ListView(
       padding: const EdgeInsets.all(16),
@@ -20,29 +31,66 @@ class InsightsScreen extends StatelessWidget {
         const SizedBox(height: 12),
         const ReviewNoteCard(
           title: '리뷰 설명',
-          body: '이번 빌드에서는 Today의 진행 데이터가 최소한으로 연결되는지만 보여줍니다. '
-              '주간/월간 추이와 약점 카드 분석은 KPI 확정 후 들어갑니다.',
+          body: '이번 반복에서는 핵심 KPI 3개와 다음 행동 연결만 강화합니다. '
+              '주간/월간 추이와 장기 지표는 이벤트 스키마 확정 후 확장합니다.',
         ),
         const SizedBox(height: 12),
+        Text('핵심 KPI', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        _MetricCard(title: '오늘 완료율', value: '$completionRate%', subtitle: '${stats.completed}/${stats.target} 완료'),
+        _MetricCard(title: '정답률', value: '$accuracy%', subtitle: '알겠음 ${stats.known} / 전체 $solved'),
+        _MetricCard(title: '오늘 상태', value: todayStatus, subtitle: '헷갈림 ${stats.unsure}건 · 모르겠음 ${stats.again}건'),
+        const SizedBox(height: 8),
         Card(
-          child: ListTile(
-            title: const Text('오늘 진행'),
-            subtitle: Text('${stats.completed}/${stats.target} 완료'),
-          ),
-        ),
-        Card(
-          child: ListTile(
-            title: const Text('정답률'),
-            subtitle: Text('$accuracy%'),
-          ),
-        ),
-        Card(
-          child: ListTile(
-            title: const Text('헷갈림'),
-            subtitle: Text('${stats.unsure}건'),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('다음 행동', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                Text(
+                  stats.unsure + stats.again > 0
+                      ? '헷갈리거나 모르는 카드가 남아 있습니다. Today로 돌아가 다시 학습하세요.'
+                      : '현재 세션 기준으로 약점 카드가 많지 않습니다. 그래도 Today에서 바로 이어갈 수 있습니다.',
+                ),
+                const SizedBox(height: 12),
+                FilledButton.icon(
+                  onPressed: onStartToday,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('약점 다시 학습'),
+                ),
+              ],
+            ),
           ),
         ),
       ],
+    );
+  }
+}
+
+class _MetricCard extends StatelessWidget {
+  const _MetricCard({
+    required this.title,
+    required this.value,
+    required this.subtitle,
+  });
+
+  final String title;
+  final String value;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        title: Text(title),
+        subtitle: Text(subtitle),
+        trailing: Text(
+          value,
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+      ),
     );
   }
 }

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -53,8 +53,8 @@ void main() {
     await tester.tap(find.text('Insights').last);
     await tester.pumpAndSettle();
 
-    expect(find.text('헷갈림'), findsWidgets);
-    expect(find.text('1건'), findsOneWidget);
+    expect(find.text('오늘 상태'), findsOneWidget);
+    expect(find.textContaining('헷갈림 1건'), findsOneWidget);
   });
 
   testWidgets('Add tab validates, saves a card, and can move to Today', (WidgetTester tester) async {
@@ -113,5 +113,29 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('진행: 0 /'), findsOneWidget);
+  });
+
+  testWidgets('Insights action can move back to Today with KPI cards visible', (WidgetTester tester) async {
+    await tester.pumpWidget(const RepeatoApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('헷갈림').first);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Insights').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('오늘 완료율'), findsOneWidget);
+    expect(find.text('정답률'), findsOneWidget);
+    expect(find.text('오늘 상태'), findsOneWidget);
+    expect(find.text('진행 중'), findsOneWidget);
+
+    final retryButton = find.widgetWithText(FilledButton, '약점 다시 학습');
+    await tester.ensureVisible(retryButton);
+    await tester.pumpAndSettle();
+    await tester.tap(retryButton);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('진행: 1 /'), findsOneWidget);
   });
 }

--- a/doc/context-inbox.md
+++ b/doc/context-inbox.md
@@ -16,17 +16,17 @@
   - 
 
 ## Active
-- 날짜: 2026-03-08
-- 작업 주제: Deck 상세 화면과 Today 연결 구현
+- 날짜: 2026-03-13
+- 작업 주제: Insights KPI 대시보드 및 Today 재진입 CTA 구현
 - 임시 컨텍스트:
-  - GitHub 이슈 `#3 Connect Deck detail to Today` 생성 완료
-  - 작업 브랜치 `feat/3-decks-today-link` 생성 완료
-  - Deck 상세 화면 진입과 `학습 시작` CTA를 Today 탭 이동으로 연결
-  - Add로 늘어난 카드 수가 Deck 상세 카드 수/직접 추가 카드 수에 반영됨
+  - GitHub 이슈 `#5 [Task] Enhance Insights dashboard and action CTA` 생성 완료
+  - 작업 브랜치 `feat/5-insights-dashboard-cta` 생성 완료
+  - Insights에 핵심 KPI 3개(오늘 완료율, 정답률, 오늘 상태)와 `약점 다시 학습` CTA를 추가
+  - 탭 전환 시 Today 세션 상태가 유지되도록 `IndexedStack` 기반 앱 셸로 변경
   - `flutter analyze` 통과
-  - `flutter test --coverage` 통과, line coverage 85.59%
+  - `flutter test --coverage` 통과, line coverage 87.43%
 - 검증 필요:
-  - Deck 상세에서 다음 복습/목표 외에 어떤 정보가 더 필요한지
-  - 다음 작업을 SQLite 설계 코드화와 Deck 상태 모델 중 무엇으로 둘지
+  - 다음 반복을 Profile 1차 설정/학습 환경 카드로 둘지, Today 2차 세션 제어 개선으로 둘지
+  - Insights 후속 범위를 이벤트 스키마 전의 lightweight 추세 카드까지 허용할지
 - 메모:
-  - coverage 70% 기준은 현재 작업에서도 충족됨
+  - coverage 70% 기준은 이번 작업에서도 충족됨

--- a/doc/context-log.md
+++ b/doc/context-log.md
@@ -298,3 +298,15 @@
 - 근거: 다음 세션에서 동일한 문서 기준으로 바로 resume 할 수 있게 최신 산출물과 blocked 상태를 snapshot에 반영해야 하기 때문이다.
 - 영향 범위: `doc/work/repeato-resume-snapshot-2026-03-08-v1.md`, 이후 세션 재개 절차.
 - 후속 작업: resume 시 snapshot + `doc/next-actions.md` + `doc/context-log.md`를 함께 읽고 시작한다.
+
+- 날짜: 2026-03-13
+- 결정: `Insights` 1차 반복은 GitHub 이슈 `#5`와 브랜치 `feat/5-insights-dashboard-cta`에서 진행하고, 범위는 핵심 KPI 3개와 Today 재진입 CTA, 탭 상태 보존으로 제한한다.
+- 근거: 사용자가 각 메뉴별로 동일한 개발 루프를 반복 수행하길 요청했고, 현재 Insights는 이벤트 스키마 확정 전에도 작은 단위의 사용자 가치(KPI 요약과 즉시 재학습 연결)를 검증할 수 있기 때문이다.
+- 영향 범위: `app/lib/app_root.dart`, `app/lib/screens/insights_screen.dart`, `app/test/widget_test.dart`, GitHub issue `#5`.
+- 후속 작업: PR 본문에 KPI 범위 제한과 탭 상태 보존 이유를 명시하고, 다음 메뉴 반복은 `Profile` 또는 `Today` 2차 작업으로 넘긴다.
+
+- 날짜: 2026-03-13
+- 결정: 이번 `Insights` 1차 반복 검증 결과는 `flutter analyze` 통과, `flutter test --coverage` 통과, line coverage `87.43%`로 기록한다.
+- 근거: 개발 조직 workflow의 품질 기준인 line coverage 70% 이상 유지를 메뉴 반복 작업에도 동일하게 적용해야 하기 때문이다.
+- 영향 범위: QA 게이트, PR 본문 커버리지 기록, 다음 메뉴 반복의 검증 포맷.
+- 후속 작업: 다음 메뉴 반복에서도 동일한 coverage 계산 명령(`coverage/lcov.info` 기반)을 유지한다.

--- a/doc/next-actions.md
+++ b/doc/next-actions.md
@@ -1,11 +1,13 @@
 # Next Actions
 
 ## Priority Queue
-1. [ ] (P1) `#STAGE-C #TASK-DATA #TASK-APP #ORG-ARCH #ORG-DATA #ORG-FE` Flutter 로컬 SQLite 저장 계층과 도메인 모델 설계안을 코드 구조로 내리기 (`doc/work/repeato-local-first-architecture-v1.md`)
-2. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` Deck 상태 모델 확장(진행 중/일시중지/완료)과 상세 정보 고도화
-3. [ ] (P1) `#STAGE-C #TASK-WORKFLOW #ORG-WF-ARCH #ORG-WF-LIB #ORG-WF-AUTO #ORG-PM` workflow 조직 세션 기준 문서 유지 및 coverage 70% 운영 규칙을 다음 개발 이슈/PR에 계속 적용
-4. [ ] (P1) `#STAGE-B #TASK-LEARNING #TASK-TAB #ORG-PM #ORG-DESIGN #ORG-EDU #ORG-COG` 카드 템플릿/정답 판정/세션 규칙과 공통 상태 키 확정 (`doc/plan-checklist.md` + `doc/work/repeato-cross-tab-conflict-review-v1.md`)
-5. [ ] (P1) `#STAGE-C #TASK-DATA #ORG-PM #ORG-DATA #ORG-ARCH` KPI/이벤트 스키마 확정 후 `Insights` 구현 착수 (`doc/work/repeato-insights-tab-spec-v1.md`)
+1. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DESIGN #ORG-QA` `Profile` 1차 반복: 학습 환경/리마인드/진도 요약 카드 추가 및 설정 CTA 정리
+2. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` `Today` 2차 반복: 세션 리셋/목표 변경/약점 재진입 흐름 고도화
+3. [ ] (P1) `#STAGE-C #TASK-DATA #TASK-APP #ORG-ARCH #ORG-DATA #ORG-FE` Flutter 로컬 SQLite 저장 계층과 도메인 모델 설계안을 코드 구조로 내리기 (`doc/work/repeato-local-first-architecture-v1.md`)
+4. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` Deck 상태 모델 확장(진행 중/일시중지/완료)과 상세 정보 고도화
+5. [ ] (P1) `#STAGE-C #TASK-WORKFLOW #ORG-WF-ARCH #ORG-WF-LIB #ORG-WF-AUTO #ORG-PM` workflow 조직 세션 기준 문서 유지 및 coverage 70% 운영 규칙을 다음 개발 이슈/PR에 계속 적용
+6. [ ] (P1) `#STAGE-B #TASK-LEARNING #TASK-TAB #ORG-PM #ORG-DESIGN #ORG-EDU #ORG-COG` 카드 템플릿/정답 판정/세션 규칙과 공통 상태 키 확정 (`doc/plan-checklist.md` + `doc/work/repeato-cross-tab-conflict-review-v1.md`)
+7. [ ] (P1) `#STAGE-C #TASK-DATA #ORG-PM #ORG-DATA #ORG-ARCH` KPI/이벤트 스키마 확정 후 `Insights` 2차 구현 착수 (`doc/work/repeato-insights-tab-spec-v1.md`)
 6. [ ] (P2) `#STAGE-E #TASK-SYNC #TASK-SERVERLESS #ORG-DATA #ORG-SEC #ORG-SRE` 동기화/결제는 기획안 유지, Google Drive 기반 서버리스안 상세 검토만 진행
 7. [ ] (P2) `#STAGE-B #TASK-TAB #ORG-PM #ORG-DESIGN #ORG-QA` 각 탭 사용자 확인 질문을 인터뷰 스크립트로 전환하고 실제 피드백 수집
 
@@ -14,6 +16,12 @@
 - Flutter line coverage 측정/기록 방식은 다음 개발 이슈에서 실제 명령과 보고 포맷을 고정할 필요가 있음
 
 ## Done in This Iteration
+- Insights KPI 카드(오늘 완료율/정답률/오늘 상태) 추가
+- Insights에서 `약점 다시 학습` CTA로 Today 재진입 연결
+- 탭 전환 시 세션 상태 유지되도록 `IndexedStack` 적용
+- `flutter analyze` 통과
+- `flutter test --coverage` 통과
+- 라인 커버리지 `87.43%` 확인
 - Deck 상세 화면 진입 및 `학습 시작` CTA로 Today 이동 연결
 - Add로 증가한 카드 수를 Deck 상세에 반영
 - `flutter analyze` 통과


### PR DESCRIPTION
## 연결 이슈
- Closes #5

## 요약
- `Insights` 탭에 핵심 KPI 카드 3종(`오늘 완료율`, `정답률`, `오늘 상태`)을 추가했습니다
- `약점 다시 학습` CTA를 추가해 `Today` 탭으로 바로 재진입할 수 있도록 연결했습니다
- 탭 전환 시 `Today` 세션 상태가 유지되도록 앱 셸을 `IndexedStack` 구조로 변경했습니다
- 위젯 테스트를 보강해 `Insights -> Today` 복귀 흐름을 검증했습니다

## Agent 로그
- PM: 범위를 `Insights` 1차 가치 검증으로 제한하고 다음 반복 큐를 `Profile 1차 -> Today 2차`로 정리했습니다
- Architect: 탭 전환 시 세션 상태 유실을 막기 위해 상태 보존 구조를 적용했습니다
- Engineer: KPI 카드/CTA/테스트를 구현했습니다
- QA: 분석, 테스트, line coverage 게이트를 확인했습니다

## 테스트
- [x] `flutter analyze`
- [x] `flutter test --coverage`
- [x] coverage >= 70%
- [ ] manual QA

## 커버리지
- 현재 line coverage: `87.43%`
- 70% 미만일 때 사유: 해당 없음
- 후속 계획 / 담당: 다음 메뉴 반복에서도 동일 계산식 유지

## 사용자 영향
- 사용자가 `Insights`에서 현재 세션 상태를 더 빨리 파악할 수 있습니다
- 약점 카드가 남았을 때 바로 `Today`로 돌아가 이어서 학습할 수 있습니다
- 탭을 오가도 `Today` 진행 상태가 유지됩니다

## QA 포인트
- `Insights` KPI 카드 3종 노출
- `약점 다시 학습` CTA의 `Today` 복귀
- 탭 전환 후 `Today` 진행 수치 유지

## PM 의사결정 필요 항목
- 없음