### PR TITLE
Profile 신뢰 요약 카드와 Today 복귀 CTA

### DIFF
--- a/app/lib/app_root.dart
+++ b/app/lib/app_root.dart
@@ -152,7 +152,11 @@ class _AppRootState extends State<AppRoot> {
         stats: _stats,
         onStartToday: () => setState(() => _currentIndex = 0),
       ),
-      const ProfileScreen(),
+      ProfileScreen(
+        stats: _stats,
+        totalCards: _cards.length,
+        onResumeToday: () => setState(() => _currentIndex = 0),
+      ),
     ];
 
     return Scaffold(

--- a/app/lib/screens/profile_screen.dart
+++ b/app/lib/screens/profile_screen.dart
@@ -1,12 +1,30 @@
 import 'package:flutter/material.dart';
 
+import '../models/session_stats.dart';
 import '../widgets/review_note_card.dart';
 
 class ProfileScreen extends StatelessWidget {
-  const ProfileScreen({super.key});
+  const ProfileScreen({
+    super.key,
+    required this.stats,
+    required this.totalCards,
+    required this.onResumeToday,
+  });
+
+  final SessionStats stats;
+  final int totalCards;
+  final VoidCallback onResumeToday;
 
   @override
   Widget build(BuildContext context) {
+    final solved = stats.known + stats.unsure + stats.again;
+    final accuracy = solved == 0 ? 0 : ((stats.known / solved) * 100).round();
+    final statusText = solved == 0
+        ? '아직 시작 전'
+        : stats.done
+            ? '오늘 목표 달성'
+            : '오늘 학습 진행 중';
+
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -17,18 +35,55 @@ class ProfileScreen extends StatelessWidget {
           body: '동기화/결제는 이번 버전에서 구현하지 않습니다. 사용자 그룹에는 "로컬 설정과 상태 설명이 충분한지"만 확인합니다.',
         ),
         const SizedBox(height: 12),
-        const Card(
+        Card(
           child: ListTile(
-            leading: Icon(Icons.flag_outlined),
-            title: Text('Iteration 1 범위'),
-            subtitle: Text('로컬 MVP 중심 · 동기화/결제는 설계만 유지'),
+            leading: const Icon(Icons.insights_outlined),
+            title: const Text('오늘 학습 요약'),
+            subtitle: Text(
+              '$statusText · ${stats.completed}/${stats.target} 진행 · 정답률 $accuracy%',
+            ),
+            trailing: Text('$totalCards장'),
+          ),
+        ),
+        Card(
+          child: ListTile(
+            leading: const Icon(Icons.cloud_off_outlined),
+            title: const Text('로컬 저장 상태'),
+            subtitle: const Text('이 기기에서만 학습 상태를 보관합니다. 동기화/결제는 아직 연결하지 않았습니다.'),
+            trailing: Chip(
+              label: const Text('로컬 전용'),
+              backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+            ),
           ),
         ),
         const Card(
           child: ListTile(
             leading: Icon(Icons.notifications_none),
             title: Text('약한 리마인드'),
-            subtitle: Text('짬시간 시작형 알림(예측 기반)은 다음 단계에서 연결합니다.'),
+            subtitle: Text('등교 전이나 이동 직전처럼 짧게 시작할 수 있는 시점만 부드럽게 알려줍니다.'),
+          ),
+        ),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('다음 행동', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                Text(
+                  solved == 0
+                      ? '오늘 세션이 아직 시작되지 않았습니다. Today에서 바로 시작할 수 있습니다.'
+                      : '현재 세션이 저장돼 있습니다. Today로 돌아가 이어서 학습하세요.',
+                ),
+                const SizedBox(height: 12),
+                FilledButton.icon(
+                  onPressed: onResumeToday,
+                  icon: const Icon(Icons.play_arrow),
+                  label: const Text('Today 이어서 학습'),
+                ),
+              ],
+            ),
           ),
         ),
       ],

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -138,4 +138,29 @@ void main() {
 
     expect(find.textContaining('진행: 1 /'), findsOneWidget);
   });
+
+  testWidgets('Profile shows trust summary and can resume Today', (WidgetTester tester) async {
+    await tester.pumpWidget(const RepeatoApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('알겠음').first);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Profile').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('오늘 학습 요약'), findsOneWidget);
+    expect(find.textContaining('1/30 진행'), findsOneWidget);
+    expect(find.text('로컬 저장 상태'), findsOneWidget);
+    expect(find.text('로컬 전용'), findsOneWidget);
+    expect(find.text('Today 이어서 학습'), findsOneWidget);
+
+    final resumeButton = find.widgetWithText(FilledButton, 'Today 이어서 학습');
+    await tester.ensureVisible(resumeButton);
+    await tester.pumpAndSettle();
+    await tester.tap(resumeButton);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('진행: 1 /'), findsOneWidget);
+  });
 }

--- a/doc/context-inbox.md
+++ b/doc/context-inbox.md
@@ -17,16 +17,16 @@
 
 ## Active
 - 날짜: 2026-03-13
-- 작업 주제: Insights KPI 대시보드 및 Today 재진입 CTA 구현
+- 작업 주제: Profile 신뢰 요약 카드 및 Today 복귀 CTA 구현
 - 임시 컨텍스트:
-  - GitHub 이슈 `#5 [Task] Enhance Insights dashboard and action CTA` 생성 완료
-  - 작업 브랜치 `feat/5-insights-dashboard-cta` 생성 완료
-  - Insights에 핵심 KPI 3개(오늘 완료율, 정답률, 오늘 상태)와 `약점 다시 학습` CTA를 추가
-  - 탭 전환 시 Today 세션 상태가 유지되도록 `IndexedStack` 기반 앱 셸로 변경
+  - GitHub 이슈 `#7 [Task] Improve Profile trust summary and Today resume CTA` 생성 완료
+  - 작업 브랜치 `feat/7-profile-trust-summary` 생성 완료
+  - Profile에 오늘 학습 요약, 로컬 저장 상태, 약한 리마인드, `Today 이어서 학습` CTA를 추가
+  - Today 세션 상태를 Profile에서도 읽을 수 있도록 앱 루트 연결
   - `flutter analyze` 통과
-  - `flutter test --coverage` 통과, line coverage 87.43%
+  - `flutter test --coverage` 통과, line coverage 88.25%
 - 검증 필요:
-  - 다음 반복을 Profile 1차 설정/학습 환경 카드로 둘지, Today 2차 세션 제어 개선으로 둘지
-  - Insights 후속 범위를 이벤트 스키마 전의 lightweight 추세 카드까지 허용할지
+  - 다음 반복을 Today 2차 세션 제어 개선으로 바로 이어갈지
+  - Profile 2차에서 목표 카드 수 설정까지 연결할지
 - 메모:
   - coverage 70% 기준은 이번 작업에서도 충족됨

--- a/doc/context-log.md
+++ b/doc/context-log.md
@@ -310,3 +310,15 @@
 - 근거: 개발 조직 workflow의 품질 기준인 line coverage 70% 이상 유지를 메뉴 반복 작업에도 동일하게 적용해야 하기 때문이다.
 - 영향 범위: QA 게이트, PR 본문 커버리지 기록, 다음 메뉴 반복의 검증 포맷.
 - 후속 작업: 다음 메뉴 반복에서도 동일한 coverage 계산 명령(`coverage/lcov.info` 기반)을 유지한다.
+
+- 날짜: 2026-03-13
+- 결정: `Profile` 1차 반복은 GitHub 이슈 `#7`과 브랜치 `feat/7-profile-trust-summary`에서 진행하고, 범위는 오늘 학습 요약, 로컬 저장 상태, 약한 리마인드, Today 복귀 CTA로 제한한다.
+- 근거: `Profile` 탭은 설정 허브보다 신뢰 확인 화면이 우선이며, 서버 범위를 열지 않고도 현재 세션 요약과 로컬 상태를 보여주는 작은 단위 개선이 가능하기 때문이다.
+- 영향 범위: `app/lib/app_root.dart`, `app/lib/screens/profile_screen.dart`, `app/test/widget_test.dart`, GitHub issue `#7`.
+- 후속 작업: 다음 반복은 `Today` 2차 세션 제어 개선으로 넘기고, `Profile` 2차에서는 목표 카드 수 설정 연결 여부를 검토한다.
+
+- 날짜: 2026-03-13
+- 결정: 이번 `Profile` 1차 반복 검증 결과는 `flutter analyze` 통과, `flutter test --coverage` 통과, line coverage `88.25%`로 기록한다.
+- 근거: 메뉴 반복 작업에서도 테스트 line coverage 70% 이상 유지 규칙을 동일하게 적용해야 하기 때문이다.
+- 영향 범위: QA 게이트, PR 본문 커버리지 기록, 다음 반복의 검증 포맷.
+- 후속 작업: 다음 반복에서도 `coverage/lcov.info` 기반 line coverage 계산식을 유지한다.

--- a/doc/next-actions.md
+++ b/doc/next-actions.md
@@ -1,8 +1,8 @@
 # Next Actions
 
 ## Priority Queue
-1. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DESIGN #ORG-QA` `Profile` 1차 반복: 학습 환경/리마인드/진도 요약 카드 추가 및 설정 CTA 정리
-2. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` `Today` 2차 반복: 세션 리셋/목표 변경/약점 재진입 흐름 고도화
+1. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` `Today` 2차 반복: 세션 리셋/목표 변경/약점 재진입 흐름 고도화
+2. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DESIGN #ORG-QA` `Profile` 2차 반복: 목표 카드 수 설정과 전역 상태 키 연결 검토
 3. [ ] (P1) `#STAGE-C #TASK-DATA #TASK-APP #ORG-ARCH #ORG-DATA #ORG-FE` Flutter 로컬 SQLite 저장 계층과 도메인 모델 설계안을 코드 구조로 내리기 (`doc/work/repeato-local-first-architecture-v1.md`)
 4. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` Deck 상태 모델 확장(진행 중/일시중지/완료)과 상세 정보 고도화
 5. [ ] (P1) `#STAGE-C #TASK-WORKFLOW #ORG-WF-ARCH #ORG-WF-LIB #ORG-WF-AUTO #ORG-PM` workflow 조직 세션 기준 문서 유지 및 coverage 70% 운영 규칙을 다음 개발 이슈/PR에 계속 적용
@@ -16,6 +16,12 @@
 - Flutter line coverage 측정/기록 방식은 다음 개발 이슈에서 실제 명령과 보고 포맷을 고정할 필요가 있음
 
 ## Done in This Iteration
+- Profile에 오늘 학습 요약 카드 추가
+- Profile에 로컬 저장 상태와 약한 리마인드 설명 추가
+- `Today 이어서 학습` CTA 연결
+- `flutter analyze` 통과
+- `flutter test --coverage` 통과
+- 라인 커버리지 `88.25%` 확인
 - Insights KPI 카드(오늘 완료율/정답률/오늘 상태) 추가
 - Insights에서 `약점 다시 학습` CTA로 Today 재진입 연결
 - 탭 전환 시 세션 상태 유지되도록 `IndexedStack` 적용


### PR DESCRIPTION
## 연결 이슈
- Closes #7

## 요약
- `Profile` 탭에 오늘 학습 요약 카드를 추가했습니다
- 로컬 저장 상태와 약한 리마인드 정책을 신뢰 중심 카드로 정리했습니다
- `Today 이어서 학습` CTA를 추가해 현재 세션으로 바로 복귀할 수 있게 했습니다
- 위젯 테스트를 보강해 `Profile -> Today` 복귀와 진행 요약 노출을 검증했습니다

## Agent 로그
- PM: 범위를 신뢰 요약 중심으로 제한하고 다음 반복 큐를 `Today 2차`로 정리했습니다
- Architect: 서버 상태 머신 대신 앱 루트 세션 요약을 `Profile`에서 읽는 로컬 연결만 추가했습니다
- Frontend Engineer: 요약 카드, 로컬 상태 카드, 리마인드 설명, Today 복귀 CTA를 구현했습니다
- QA Engineer: 분석/테스트/coverage 게이트를 확인했습니다

## 테스트
- [x] `flutter analyze`
- [x] `flutter test --coverage`
- [x] coverage >= 70%
- [ ] manual QA

## 커버리지
- 현재 line coverage: `88.25%`
- 70% 미만일 때 사유: 해당 없음
- 후속 계획 / 담당: 다음 메뉴 반복에서도 동일 계산식 유지

## 사용자 영향
- 사용자가 `Profile`에서 현재 학습 상태와 로컬 저장 범위를 명확히 이해할 수 있습니다
- 학습을 중단한 뒤에도 `Profile`에서 바로 `Today`로 복귀할 수 있습니다

## QA 포인트
- `Profile`의 오늘 학습 요약 노출
- `로컬 저장 상태` 및 `로컬 전용` 표시
- `Today 이어서 학습` CTA의 정상 복귀

## PM 의사결정 필요 항목
- 없음