### PR TITLE
Today 세션 제어와 리셋 흐름 개선

### DIFF
--- a/app/lib/screens/today_screen.dart
+++ b/app/lib/screens/today_screen.dart
@@ -86,6 +86,17 @@ class _TodayScreenState extends State<TodayScreen> {
     });
   }
 
+  void _resetSession() {
+    setState(() {
+      _index = 0;
+      _known = 0;
+      _unsure = 0;
+      _again = 0;
+      _showMeaning = false;
+      _emitStats();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final done = _index >= _target;
@@ -116,21 +127,47 @@ class _TodayScreenState extends State<TodayScreen> {
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
                   const SizedBox(height: 12),
-                  Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: [
-                      ChoiceChip(
-                        label: const Text('빠른 30카드'),
-                        selected: _target == 30,
-                        onSelected: (_) => _setTarget(30),
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text('세션 제어', style: Theme.of(context).textTheme.titleMedium),
+                          const SizedBox(height: 8),
+                          Text(
+                            done
+                                ? '오늘 목표를 완료했습니다. 같은 목표로 다시 시작하거나 목표 수를 바꿀 수 있습니다.'
+                                : _index == 0
+                                    ? '아직 세션을 시작하지 않았습니다. 목표 카드 수를 고르고 바로 시작하세요.'
+                                    : '현재 세션이 진행 중입니다. 목표를 바꾸거나 같은 목표로 다시 시작할 수 있습니다.',
+                          ),
+                          const SizedBox(height: 12),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: [
+                              ChoiceChip(
+                                label: const Text('빠른 30카드'),
+                                selected: _target == 30,
+                                onSelected: (_) => _setTarget(30),
+                              ),
+                              ChoiceChip(
+                                label: const Text('집중 60카드'),
+                                selected: _target == 60,
+                                onSelected: (_) => _setTarget(60),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 12),
+                          OutlinedButton.icon(
+                            onPressed: _resetSession,
+                            icon: const Icon(Icons.restart_alt),
+                            label: const Text('현재 세션 다시 시작'),
+                          ),
+                        ],
                       ),
-                      ChoiceChip(
-                        label: const Text('집중 60카드'),
-                        selected: _target == 60,
-                        onSelected: (_) => _setTarget(60),
-                      ),
-                    ],
+                    ),
                   ),
                   const SizedBox(height: 12),
                   LinearProgressIndicator(value: progress),

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -25,11 +25,31 @@ void main() {
     expect(find.textContaining('진행: 1 /'), findsOneWidget);
   });
 
+  testWidgets('Today session controls can reset progress and switch target', (WidgetTester tester) async {
+    await tester.pumpWidget(const RepeatoApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text('세션 제어'), findsOneWidget);
+    await tester.tap(find.text('헷갈림').first);
+    await tester.pumpAndSettle();
+    expect(find.textContaining('진행: 1 / 30'), findsOneWidget);
+
+    await tester.tap(find.text('현재 세션 다시 시작'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('진행: 0 / 30'), findsOneWidget);
+
+    await tester.tap(find.text('집중 60카드'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('진행: 0 / 60'), findsOneWidget);
+  });
+
   testWidgets('Swipe gestures advance card (left=known, right=again)', (WidgetTester tester) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
-    final card = find.byType(Card).first;
+    final card = find.byWidgetPredicate(
+      (widget) => widget is GestureDetector && widget.onHorizontalDragStart != null,
+    );
     expect(find.textContaining('진행: 0 /'), findsOneWidget);
 
     // Left swipe => known
@@ -38,7 +58,12 @@ void main() {
     expect(find.textContaining('진행: 1 /'), findsOneWidget);
 
     // Right swipe => dont know
-    await tester.drag(card, const Offset(220, 0));
+    await tester.drag(
+      find.byWidgetPredicate(
+        (widget) => widget is GestureDetector && widget.onHorizontalDragStart != null,
+      ),
+      const Offset(220, 0),
+    );
     await tester.pumpAndSettle();
     expect(find.textContaining('진행: 2 /'), findsOneWidget);
   });

--- a/doc/context-inbox.md
+++ b/doc/context-inbox.md
@@ -17,16 +17,16 @@
 
 ## Active
 - 날짜: 2026-03-13
-- 작업 주제: Profile 신뢰 요약 카드 및 Today 복귀 CTA 구현
+- 작업 주제: Today 세션 제어와 리셋 흐름 개선
 - 임시 컨텍스트:
-  - GitHub 이슈 `#7 [Task] Improve Profile trust summary and Today resume CTA` 생성 완료
-  - 작업 브랜치 `feat/7-profile-trust-summary` 생성 완료
-  - Profile에 오늘 학습 요약, 로컬 저장 상태, 약한 리마인드, `Today 이어서 학습` CTA를 추가
-  - Today 세션 상태를 Profile에서도 읽을 수 있도록 앱 루트 연결
+  - GitHub 이슈 `#9 Today 세션 제어와 리셋 흐름 개선` 생성 완료
+  - 작업 브랜치 `feat/9-today-session-controls` 생성 완료
+  - Today 상단에 세션 제어 카드와 명시적 `현재 세션 다시 시작` CTA를 추가
+  - 목표 변경(`빠른 30카드`, `집중 60카드`) 흐름을 세션 제어 카드 안에서 명확화
   - `flutter analyze` 통과
-  - `flutter test --coverage` 통과, line coverage 88.25%
+  - `flutter test --coverage` 통과, line coverage 90.65%
 - 검증 필요:
-  - 다음 반복을 Today 2차 세션 제어 개선으로 바로 이어갈지
-  - Profile 2차에서 목표 카드 수 설정까지 연결할지
+  - 다음 반복을 Add 2차 또는 Decks 2차 중 어디로 둘지
+  - Today 3차에서 약점 카드 재도전 큐를 실제로 둘지
 - 메모:
   - coverage 70% 기준은 이번 작업에서도 충족됨

--- a/doc/context-log.md
+++ b/doc/context-log.md
@@ -322,3 +322,15 @@
 - 근거: 메뉴 반복 작업에서도 테스트 line coverage 70% 이상 유지 규칙을 동일하게 적용해야 하기 때문이다.
 - 영향 범위: QA 게이트, PR 본문 커버리지 기록, 다음 반복의 검증 포맷.
 - 후속 작업: 다음 반복에서도 `coverage/lcov.info` 기반 line coverage 계산식을 유지한다.
+
+- 날짜: 2026-03-13
+- 결정: `Today` 2차 반복은 GitHub 이슈 `#9`와 브랜치 `feat/9-today-session-controls`에서 진행하고, 범위는 세션 제어 카드, 명시적 리셋 CTA, 목표 변경 흐름 명확화로 제한한다.
+- 근거: 각 메뉴별 반복 작업을 계속 진행하는 현재 루프에서 `Today`는 핵심 사용 흐름이므로, 데이터 모델 확장 전에 세션 제어를 더 명확히 보여주는 작은 반복이 우선 가치가 높기 때문이다.
+- 영향 범위: `app/lib/screens/today_screen.dart`, `app/test/widget_test.dart`, GitHub issue `#9`.
+- 후속 작업: 다음 반복은 `Add` 2차 또는 `Decks` 2차 중 하나로 넘기고, `Today` 3차에서는 약점 카드 재도전 큐 도입 여부를 검토한다.
+
+- 날짜: 2026-03-13
+- 결정: 이번 `Today` 2차 반복 검증 결과는 `flutter analyze` 통과, `flutter test --coverage` 통과, line coverage `90.65%`로 기록한다.
+- 근거: 반복 구현에서도 line coverage 70% 이상 유지 규칙을 지속적으로 증명해야 하기 때문이다.
+- 영향 범위: QA 게이트, PR 본문 커버리지 기록, 다음 반복의 검증 포맷.
+- 후속 작업: 다음 반복에서도 `coverage/lcov.info` 기반 line coverage 계산식을 유지한다.

--- a/doc/next-actions.md
+++ b/doc/next-actions.md
@@ -1,10 +1,10 @@
 # Next Actions
 
 ## Priority Queue
-1. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` `Today` 2차 반복: 세션 리셋/목표 변경/약점 재진입 흐름 고도화
-2. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DESIGN #ORG-QA` `Profile` 2차 반복: 목표 카드 수 설정과 전역 상태 키 연결 검토
-3. [ ] (P1) `#STAGE-C #TASK-DATA #TASK-APP #ORG-ARCH #ORG-DATA #ORG-FE` Flutter 로컬 SQLite 저장 계층과 도메인 모델 설계안을 코드 구조로 내리기 (`doc/work/repeato-local-first-architecture-v1.md`)
-4. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` Deck 상태 모델 확장(진행 중/일시중지/완료)과 상세 정보 고도화
+1. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` `Add` 2차 반복: 입력 히스토리/최근 덱 제안/저장 후 재입력 흐름 고도화
+2. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` `Decks` 2차 반복: 덱 카드 상태 배지와 정렬/필터 기본값 고도화
+3. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DESIGN #ORG-QA` `Profile` 2차 반복: 목표 카드 수 설정과 전역 상태 키 연결 검토
+4. [ ] (P1) `#STAGE-C #TASK-DATA #TASK-APP #ORG-ARCH #ORG-DATA #ORG-FE` Flutter 로컬 SQLite 저장 계층과 도메인 모델 설계안을 코드 구조로 내리기 (`doc/work/repeato-local-first-architecture-v1.md`)
 5. [ ] (P1) `#STAGE-C #TASK-WORKFLOW #ORG-WF-ARCH #ORG-WF-LIB #ORG-WF-AUTO #ORG-PM` workflow 조직 세션 기준 문서 유지 및 coverage 70% 운영 규칙을 다음 개발 이슈/PR에 계속 적용
 6. [ ] (P1) `#STAGE-B #TASK-LEARNING #TASK-TAB #ORG-PM #ORG-DESIGN #ORG-EDU #ORG-COG` 카드 템플릿/정답 판정/세션 규칙과 공통 상태 키 확정 (`doc/plan-checklist.md` + `doc/work/repeato-cross-tab-conflict-review-v1.md`)
 7. [ ] (P1) `#STAGE-C #TASK-DATA #ORG-PM #ORG-DATA #ORG-ARCH` KPI/이벤트 스키마 확정 후 `Insights` 2차 구현 착수 (`doc/work/repeato-insights-tab-spec-v1.md`)
@@ -16,6 +16,12 @@
 - Flutter line coverage 측정/기록 방식은 다음 개발 이슈에서 실제 명령과 보고 포맷을 고정할 필요가 있음
 
 ## Done in This Iteration
+- Today 상단 세션 제어 카드 추가
+- `현재 세션 다시 시작` CTA 추가
+- 목표 변경 흐름(`빠른 30카드`, `집중 60카드`) 명확화
+- `flutter analyze` 통과
+- `flutter test --coverage` 통과
+- 라인 커버리지 `90.65%` 확인
 - Profile에 오늘 학습 요약 카드 추가
 - Profile에 로컬 저장 상태와 약한 리마인드 설명 추가
 - `Today 이어서 학습` CTA 연결


### PR DESCRIPTION
## 연결 이슈
- Closes #9

## 요약
- `Today` 상단에 세션 제어 카드를 추가했습니다
- 목표 변경 흐름(`빠른 30카드`, `집중 60카드`)을 세션 제어 카드 안에서 명확히 드러냈습니다
- `현재 세션 다시 시작` CTA를 추가해 진행 중 세션을 즉시 리셋할 수 있게 했습니다
- 위젯 테스트를 보강해 리셋, 목표 변경, 기존 스와이프 흐름을 함께 검증했습니다

## Agent 로그
- PM: 범위를 세션 제어 명확화에 제한하고 다음 반복 큐를 `Add 2차 -> Decks 2차`로 정리했습니다
- Architect: 기존 로컬 세션 구조를 유지하면서 세션 제어/리셋 동작을 상단 카드로 끌어올렸습니다
- Frontend Engineer: 세션 제어 카드, 리셋 CTA, 목표 변경 UI를 구현했습니다
- QA Engineer: 분석/테스트/coverage 게이트를 확인했습니다

## 테스트
- [x] `flutter analyze`
- [x] `flutter test --coverage`
- [x] coverage >= 70%
- [ ] manual QA

## 커버리지
- 현재 line coverage: `90.65%`
- 70% 미만일 때 사유: 해당 없음
- 후속 계획 / 담당: 다음 메뉴 반복에서도 동일 계산식 유지

## 사용자 영향
- 사용자가 `Today`에서 현재 세션 상태와 제어 옵션을 더 빨리 이해할 수 있습니다
- 진행 중인 세션을 한 번에 리셋하거나 목표를 바꾸기 쉬워졌습니다

## QA 포인트
- `세션 제어` 카드 노출
- `현재 세션 다시 시작` 동작
- `빠른 30카드`/`집중 60카드` 전환 시 진행 수치 초기화
- 기존 스와이프/탭 학습 흐름 회귀 여부

## PM 의사결정 필요 항목
- 없음