### PR TITLE
Insights 약점 영역 요약과 덱 확인 CTA 추가

### DIFF
--- a/app/lib/app_root.dart
+++ b/app/lib/app_root.dart
@@ -153,6 +153,7 @@ class _AppRootState extends State<AppRoot> {
         deckName: '중2 초급 영어',
         totalCards: _cards.length,
         onStartToday: () => setState(() => _currentIndex = 0),
+        onOpenDeck: () => setState(() => _currentIndex = 1),
       ),
       ProfileScreen(
         stats: _stats,

--- a/app/lib/screens/insights_screen.dart
+++ b/app/lib/screens/insights_screen.dart
@@ -10,12 +10,14 @@ class InsightsScreen extends StatelessWidget {
     required this.deckName,
     required this.totalCards,
     required this.onStartToday,
+    required this.onOpenDeck,
   });
 
   final SessionStats stats;
   final String deckName;
   final int totalCards;
   final VoidCallback onStartToday;
+  final VoidCallback onOpenDeck;
 
   @override
   Widget build(BuildContext context) {
@@ -25,6 +27,11 @@ class InsightsScreen extends StatelessWidget {
     final deckProgressCount = stats.completed > totalCards ? totalCards : stats.completed;
     final deckProgressRate = totalCards == 0 ? 0 : ((deckProgressCount / totalCards) * 100).round();
     final todayRemaining = stats.target - stats.completed < 0 ? 0 : stats.target - stats.completed;
+    final weakFocus = stats.again > stats.unsure
+        ? '기억이 거의 나지 않는 카드가 더 많습니다.'
+        : stats.unsure > 0
+            ? '헷갈리는 카드가 더 많아 빠른 재확인이 필요합니다.'
+            : '뚜렷한 약점 응답은 아직 많지 않습니다.';
     final todayStatus = stats.done
         ? '오늘 목표 달성'
         : solved == 0
@@ -88,6 +95,30 @@ class InsightsScreen extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                Text('약점 영역 요약', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                Text(weakFocus),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    Chip(label: Text('헷갈림 ${stats.unsure}장')),
+                    Chip(label: Text('모르겠음 ${stats.again}장')),
+                    Chip(label: Text('남은 카드 $todayRemaining장')),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
                 Text('다음 행동', style: Theme.of(context).textTheme.titleMedium),
                 const SizedBox(height: 8),
                 Text(
@@ -96,10 +127,21 @@ class InsightsScreen extends StatelessWidget {
                       : '현재 세션 기준으로 약점 카드가 많지 않습니다. 그래도 Today에서 바로 이어갈 수 있습니다.',
                 ),
                 const SizedBox(height: 12),
-                FilledButton.icon(
-                  onPressed: onStartToday,
-                  icon: const Icon(Icons.refresh),
-                  label: const Text('약점 다시 학습'),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  children: [
+                    FilledButton.icon(
+                      onPressed: onStartToday,
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('약점 다시 학습'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: onOpenDeck,
+                      icon: const Icon(Icons.menu_book_outlined),
+                      label: const Text('덱 확인하기'),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -102,6 +102,32 @@ void main() {
     expect(find.text('29장'), findsOneWidget);
   });
 
+  testWidgets('Insights weak summary can open Decks tab', (WidgetTester tester) async {
+    await tester.pumpWidget(const RepeatoApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('모르겠음').first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Insights').last);
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(Scrollable).last, const Offset(0, -400));
+    await tester.pumpAndSettle();
+
+    expect(find.text('약점 영역 요약'), findsOneWidget);
+    expect(find.text('기억이 거의 나지 않는 카드가 더 많습니다.'), findsOneWidget);
+    expect(find.text('모르겠음 1장'), findsOneWidget);
+
+    final openDeckButton = find.widgetWithText(OutlinedButton, '덱 확인하기');
+    await tester.ensureVisible(openDeckButton);
+    await tester.pumpAndSettle();
+    await tester.tap(openDeckButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Decks'), findsWidgets);
+    expect(find.text('중2 초급 영어 120'), findsOneWidget);
+  });
+
   testWidgets('Add tab validates, saves a card, and can move to Today', (WidgetTester tester) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
@@ -177,6 +203,8 @@ void main() {
     expect(find.text('오늘 상태'), findsOneWidget);
     expect(find.text('진행 중'), findsOneWidget);
 
+    await tester.drag(find.byType(Scrollable).last, const Offset(0, -250));
+    await tester.pumpAndSettle();
     final retryButton = find.widgetWithText(FilledButton, '약점 다시 학습');
     await tester.ensureVisible(retryButton);
     await tester.pumpAndSettle();

--- a/doc/context-inbox.md
+++ b/doc/context-inbox.md
@@ -17,17 +17,17 @@
 
 ## Active
 - 날짜: 2026-03-15
-- 작업 주제: Insights 덱 전체 진행률과 오늘 남은 카드 구현
+- 작업 주제: Insights 약점 영역 요약과 덱 확인 CTA 구현
 - 임시 컨텍스트:
-  - GitHub 이슈 `#11 Insights 덱 전체 진행률과 오늘 남은 카드 추가` 생성 완료
-  - 작업 브랜치 `feat/11-insights-deck-progress` 생성 완료
-  - `Insights`에 `현재 학습 중인 덱` 카드 추가
-  - 덱 전체 진행률과 오늘 남은 카드 수 노출 구현
-  - `doc/work/repeato-insights-user-needs-review-2026-03-15-v1.md`와 `repeato-insights-tab-spec-v1.md` 연결 완료
+  - GitHub 이슈 `#13 Insights 약점 영역 요약과 덱 확인 CTA 추가` 생성 완료
+  - 작업 브랜치 `feat/13-insights-weak-summary` 생성 완료
+  - `Insights`에 `약점 영역 요약` 카드 추가
+  - `약점 다시 학습`과 `덱 확인하기` CTA를 함께 노출
+  - `덱 확인하기` CTA가 `Decks` 탭으로 이동하도록 연결
   - `flutter analyze` 통과
-  - `flutter test --coverage` 통과, line coverage 91.53%
+  - `flutter test --coverage` 통과, line coverage 91.65%
 - 검증 필요:
-  - `덱 전체 진행률`을 현재 세션 경험 기준에서 장기 진행 기준으로 바꾸려면 어떤 저장 모델이 필요한지
-  - 다음 반복을 약점 영역 요약과 CTA 고도화로 바로 이어갈지
+  - 약점 영역을 카드/태그/주제 기준으로 세분화하려면 어떤 데이터가 필요한지
+  - 다음 반복에서 최근 변화와 다음 복습 시점을 어떤 문구로 보여줄지
 - 메모:
-  - 현재 구현의 덱 전체 진행률은 영속 학습 이력이 아니라 현재 세션 기준 경험 카드 수를 사용함
+  - 현재 약점 영역 요약은 응답 집계(`헷갈림`, `모르겠음`) 기준 해석 문구를 사용함

--- a/doc/context-log.md
+++ b/doc/context-log.md
@@ -352,3 +352,15 @@
 - 근거: 개발 workflow 품질 기준인 line coverage 70% 이상 유지 규칙을 이번 `Insights` 반복에도 동일하게 적용해야 하기 때문이다.
 - 영향 범위: QA 게이트, PR 본문 커버리지 기록, 다음 `Insights` 반복의 검증 포맷.
 - 후속 작업: 다음 반복에서도 `coverage/lcov.info` 기반 line coverage 계산식을 유지한다.
+
+- 날짜: 2026-03-15
+- 결정: `Insights` 2차 반복은 GitHub 이슈 `#13`과 브랜치 `feat/13-insights-weak-summary`에서 진행하고, 범위는 약점 영역 요약 카드, 약점 해석 문구, `덱 확인하기` CTA 추가로 제한한다.
+- 근거: 덱 전체 진행률과 오늘 남은 양을 본 뒤 사용자가 다음으로 궁금해하는 것은 `무엇이 약점인지`와 `덱 쪽으로 어떻게 넘어가는지`였기 때문이다.
+- 영향 범위: `app/lib/app_root.dart`, `app/lib/screens/insights_screen.dart`, `app/test/widget_test.dart`, GitHub issue `#13`.
+- 후속 작업: 다음 반복에서는 최근 변화와 다음 복습 시점 카드를 추가한다.
+
+- 날짜: 2026-03-15
+- 결정: 이번 `Insights 약점 영역 요약과 덱 확인 CTA` 반복 검증 결과는 `flutter analyze` 통과, `flutter test --coverage` 통과, line coverage `91.65%`로 기록한다.
+- 근거: 반복 구현에서도 line coverage 70% 이상 유지 규칙을 지속 적용해야 하기 때문이다.
+- 영향 범위: QA 게이트, PR 본문 커버리지 기록, 다음 `Insights` 반복의 검증 포맷.
+- 후속 작업: 다음 반복에서도 `coverage/lcov.info` 기반 line coverage 계산식을 유지한다.

--- a/doc/next-actions.md
+++ b/doc/next-actions.md
@@ -1,8 +1,8 @@
 # Next Actions
 
 ## Priority Queue
-1. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DATA #ORG-QA` `Insights` 2차 반복: 약점 영역 요약과 덱 맥락 CTA 고도화
-2. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DATA #ORG-QA` `Insights` 3차 반복: 최근 변화/다음 복습 시점 카드 추가
+1. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DATA #ORG-QA` `Insights` 3차 반복: 최근 변화/다음 복습 시점 카드 추가
+2. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` `Add` 2차 반복: 입력 히스토리/최근 덱 제안/저장 후 재입력 흐름 고도화
 3. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` `Add` 2차 반복: 입력 히스토리/최근 덱 제안/저장 후 재입력 흐름 고도화
 4. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DESIGN #ORG-QA` `Profile` 2차 반복: 목표 카드 수 설정과 전역 상태 키 연결 검토
 5. [ ] (P1) `#STAGE-C #TASK-DATA #TASK-APP #ORG-ARCH #ORG-DATA #ORG-FE` Flutter 로컬 SQLite 저장 계층과 도메인 모델 설계안을 코드 구조로 내리기 (`doc/work/repeato-local-first-architecture-v1.md`)
@@ -17,6 +17,11 @@
 - Flutter line coverage 측정/기록 방식은 다음 개발 이슈에서 실제 명령과 보고 포맷을 고정할 필요가 있음
 
 ## Done in This Iteration
+- `Insights`에 `약점 영역 요약` 카드 추가
+- `덱 확인하기` CTA 추가 및 `Decks` 탭 이동 연결
+- `flutter analyze` 통과
+- `flutter test --coverage` 통과
+- 라인 커버리지 `91.65%` 확인
 - `Insights`에 `현재 학습 중인 덱` 카드 추가
 - `Insights`에 덱 전체 진행률과 오늘 남은 카드 수 노출
 - `Insights` 스펙 문서에 덱 단위 진행 맥락 반영


### PR DESCRIPTION
## 연결 이슈
- Closes #13

## 요약
- `Insights`에 `약점 영역 요약` 카드를 추가했습니다
- 약점 응답을 해석한 문구와 `헷갈림`/`모르겠음`/`남은 카드` 요약 칩을 노출합니다
- `덱 확인하기` CTA를 추가해 `Decks` 탭으로 바로 이동할 수 있게 했습니다
- 위젯 테스트를 보강해 약점 요약과 덱 CTA 이동을 검증했습니다

## Agent 로그
- PM: 약점 해석과 덱 이동 연결에 집중했습니다
- Product Designer: 약점 요약 카드와 이중 CTA 구조를 적용했습니다
- Technical Architect: 응답 집계 기반 해석과 탭 전환 콜백을 사용했습니다
- Frontend Engineer: 약점 카드와 `덱 확인하기` CTA를 구현했습니다
- QA Engineer: 분석/테스트/coverage 게이트를 확인했습니다
- Data Analyst: 후속으로 `weak_area_summary` 세분화 필요를 기록했습니다

## 테스트
- [x] `flutter analyze`
- [x] `flutter test --coverage`
- [x] coverage >= 70%
- [ ] manual QA

## 커버리지
- 현재 line coverage: `91.65%`
- 70% 미만일 때 사유: 해당 없음
- 후속 계획 / 담당: 다음 `Insights` 반복에서도 동일 계산식 유지

## 사용자 영향
- 사용자가 현재 세션에서 무엇이 약점인지 더 빠르게 이해할 수 있습니다
- `Insights`에서 바로 `Decks`로 이동해 덱 맥락을 확인할 수 있습니다

## QA 포인트
- `약점 영역 요약` 카드 노출
- `덱 확인하기` CTA의 `Decks` 탭 이동
- 기존 `약점 다시 학습` CTA 회귀 여부

## PM 의사결정 필요 항목
- 없음