### PR TITLE
천자문 샘플 덱 추가와 Deck 선택 학습 1차

### DIFF
--- a/app/assets/data/cheonjamun_sample.json
+++ b/app/assets/data/cheonjamun_sample.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": 1001,
+    "word": "天",
+    "meaning_ko": "하늘 천",
+    "example_en": "Cheonjamun sample: 天 means sky.",
+    "example_ko": "천자문 샘플: 天은 하늘을 뜻한다.",
+    "level": "cheonjamun_basic",
+    "category": "hanja",
+    "deck_id": "cheonjamun_basic",
+    "deck_name": "천자문 입문"
+  },
+  {
+    "id": 1002,
+    "word": "地",
+    "meaning_ko": "땅 지",
+    "example_en": "Cheonjamun sample: 地 means ground.",
+    "example_ko": "천자문 샘플: 地는 땅을 뜻한다.",
+    "level": "cheonjamun_basic",
+    "category": "hanja",
+    "deck_id": "cheonjamun_basic",
+    "deck_name": "천자문 입문"
+  },
+  {
+    "id": 1003,
+    "word": "玄",
+    "meaning_ko": "검을 현",
+    "example_en": "Cheonjamun sample: 玄 means dark or deep.",
+    "example_ko": "천자문 샘플: 玄은 검거나 깊음을 뜻한다.",
+    "level": "cheonjamun_basic",
+    "category": "hanja",
+    "deck_id": "cheonjamun_basic",
+    "deck_name": "천자문 입문"
+  },
+  {
+    "id": 1004,
+    "word": "黃",
+    "meaning_ko": "누를 황",
+    "example_en": "Cheonjamun sample: 黃 means yellow.",
+    "example_ko": "천자문 샘플: 黃은 누런빛을 뜻한다.",
+    "level": "cheonjamun_basic",
+    "category": "hanja",
+    "deck_id": "cheonjamun_basic",
+    "deck_name": "천자문 입문"
+  },
+  {
+    "id": 1005,
+    "word": "宇",
+    "meaning_ko": "집 우",
+    "example_en": "Cheonjamun sample: 宇 can mean house or universe.",
+    "example_ko": "천자문 샘플: 宇는 집 또는 우주를 뜻한다.",
+    "level": "cheonjamun_basic",
+    "category": "hanja",
+    "deck_id": "cheonjamun_basic",
+    "deck_name": "천자문 입문"
+  },
+  {
+    "id": 1006,
+    "word": "宙",
+    "meaning_ko": "집 주",
+    "example_en": "Cheonjamun sample: 宙 is used in universe.",
+    "example_ko": "천자문 샘플: 宙는 우주를 나타낼 때 쓰인다.",
+    "level": "cheonjamun_basic",
+    "category": "hanja",
+    "deck_id": "cheonjamun_basic",
+    "deck_name": "천자문 입문"
+  },
+  {
+    "id": 1007,
+    "word": "洪",
+    "meaning_ko": "넓을 홍",
+    "example_en": "Cheonjamun sample: 洪 means vast or grand.",
+    "example_ko": "천자문 샘플: 洪은 넓고 큰 것을 뜻한다.",
+    "level": "cheonjamun_basic",
+    "category": "hanja",
+    "deck_id": "cheonjamun_basic",
+    "deck_name": "천자문 입문"
+  },
+  {
+    "id": 1008,
+    "word": "荒",
+    "meaning_ko": "거칠 황",
+    "example_en": "Cheonjamun sample: 荒 means wild or rough.",
+    "example_ko": "천자문 샘플: 荒은 거칠고 황량함을 뜻한다.",
+    "level": "cheonjamun_basic",
+    "category": "hanja",
+    "deck_id": "cheonjamun_basic",
+    "deck_name": "천자문 입문"
+  }
+]

--- a/app/lib/app_root.dart
+++ b/app/lib/app_root.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'models/session_stats.dart';
+import 'models/deck_summary.dart';
 import 'models/word_card.dart';
 import 'screens/add_screen.dart';
 import 'screens/decks_screen.dart';
@@ -23,6 +24,7 @@ class _AppRootState extends State<AppRoot> {
   int _currentIndex = 0;
   SessionStats _stats = SessionStats.empty;
   final List<WordCard> _cards = [];
+  String _selectedDeckId = 'm2_beginner_english';
   bool _isLoading = true;
   Object? _loadError;
 
@@ -53,23 +55,29 @@ class _AppRootState extends State<AppRoot> {
   }
 
   Future<List<WordCard>> _loadCards() async {
-    const assetPath = 'assets/data/m2_beginner_words.json';
-    debugPrint('[Repeato] loadCards: start ($assetPath)');
+    const assetPaths = [
+      'assets/data/m2_beginner_words.json',
+      'assets/data/cheonjamun_sample.json',
+    ];
+    final cards = <WordCard>[];
 
     try {
-      final raw = await rootBundle
-          .loadString(assetPath)
-          .timeout(const Duration(seconds: 5), onTimeout: () {
-        throw TimeoutException('Timed out loading asset: $assetPath');
-      });
-      debugPrint('[Repeato] loadCards: loaded raw (${raw.length} chars)');
+      for (final assetPath in assetPaths) {
+        debugPrint('[Repeato] loadCards: start ($assetPath)');
+        final raw = await rootBundle
+            .loadString(assetPath)
+            .timeout(const Duration(seconds: 5), onTimeout: () {
+          throw TimeoutException('Timed out loading asset: $assetPath');
+        });
+        debugPrint('[Repeato] loadCards: loaded raw (${raw.length} chars)');
 
-      final List<dynamic> decoded = jsonDecode(raw) as List<dynamic>;
-      debugPrint('[Repeato] loadCards: decoded list (${decoded.length} items)');
+        final List<dynamic> decoded = jsonDecode(raw) as List<dynamic>;
+        debugPrint('[Repeato] loadCards: decoded list (${decoded.length} items)');
 
-      final cards = decoded
-          .map((e) => WordCard.fromJson(e as Map<String, dynamic>))
-          .toList();
+        cards.addAll(
+          decoded.map((e) => WordCard.fromJson(e as Map<String, dynamic>)),
+        );
+      }
       debugPrint('[Repeato] loadCards: done (${cards.length} cards)');
       return cards;
     } catch (e, st) {
@@ -94,6 +102,8 @@ class _AppRootState extends State<AppRoot> {
       exampleKo: '$meaningKo 예문',
       level: 'custom',
       category: deck,
+      deckId: deck.trim().toLowerCase().replaceAll(' ', '_'),
+      deckName: deck,
     );
 
     setState(() {
@@ -101,6 +111,34 @@ class _AppRootState extends State<AppRoot> {
       if (moveToToday) {
         _currentIndex = 0;
       }
+    });
+  }
+
+  List<DeckSummary> _buildDecks() {
+    final grouped = <String, List<WordCard>>{};
+    for (final card in _cards) {
+      grouped.putIfAbsent(card.deckId, () => []).add(card);
+    }
+
+    final decks = grouped.entries
+        .map(
+          (entry) => DeckSummary(
+            id: entry.key,
+            name: entry.value.first.deckName,
+            totalCards: entry.value.length,
+            customCards: entry.value.where((card) => card.level == 'custom').length,
+          ),
+        )
+        .toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    return decks;
+  }
+
+  void _openDeckStudy(String deckId) {
+    setState(() {
+      _selectedDeckId = deckId;
+      _currentIndex = 0;
+      _stats = SessionStats.empty;
     });
   }
 
@@ -133,15 +171,24 @@ class _AppRootState extends State<AppRoot> {
       );
     }
 
+    final decks = _buildDecks();
+    final selectedDeck = decks.firstWhere(
+      (deck) => deck.id == _selectedDeckId,
+      orElse: () => decks.first,
+    );
+    final selectedCards = _cards.where((card) => card.deckId == selectedDeck.id).toList();
+
     final screens = <Widget>[
       TodayScreen(
-        cards: _cards,
+        key: ValueKey('today-${selectedDeck.id}'),
+        cards: selectedCards,
+        deckName: selectedDeck.name,
         onStatsChanged: (s) => setState(() => _stats = s),
       ),
       DecksScreen(
-        totalCards: _cards.length,
-        customCards: _cards.where((card) => card.level == 'custom').length,
-        onStartToday: () => setState(() => _currentIndex = 0),
+        decks: decks,
+        selectedDeckId: selectedDeck.id,
+        onStudyDeck: _openDeckStudy,
       ),
       AddScreen(
         key: const ValueKey('add-screen'),
@@ -150,14 +197,14 @@ class _AppRootState extends State<AppRoot> {
       ),
       InsightsScreen(
         stats: _stats,
-        deckName: '중2 초급 영어',
-        totalCards: _cards.length,
+        deckName: selectedDeck.name,
+        totalCards: selectedDeck.totalCards,
         onStartToday: () => setState(() => _currentIndex = 0),
         onOpenDeck: () => setState(() => _currentIndex = 1),
       ),
       ProfileScreen(
         stats: _stats,
-        totalCards: _cards.length,
+        totalCards: selectedDeck.totalCards,
         onResumeToday: () => setState(() => _currentIndex = 0),
       ),
     ];

--- a/app/lib/models/deck_summary.dart
+++ b/app/lib/models/deck_summary.dart
@@ -1,0 +1,13 @@
+class DeckSummary {
+  const DeckSummary({
+    required this.id,
+    required this.name,
+    required this.totalCards,
+    required this.customCards,
+  });
+
+  final String id;
+  final String name;
+  final int totalCards;
+  final int customCards;
+}

--- a/app/lib/models/word_card.dart
+++ b/app/lib/models/word_card.dart
@@ -7,6 +7,8 @@ class WordCard {
     required this.exampleKo,
     required this.level,
     required this.category,
+    required this.deckId,
+    required this.deckName,
   });
 
   final int id;
@@ -16,16 +18,32 @@ class WordCard {
   final String exampleKo;
   final String level;
   final String category;
+  final String deckId;
+  final String deckName;
 
   factory WordCard.fromJson(Map<String, dynamic> json) {
+    final level = json['level'] as String;
+    final defaultDeckId = switch (level) {
+      'm2_beginner' => 'm2_beginner_english',
+      'cheonjamun_basic' => 'cheonjamun_basic',
+      _ => json['category'] as String? ?? 'custom',
+    };
+    final defaultDeckName = switch (level) {
+      'm2_beginner' => '중2 초급 영어',
+      'cheonjamun_basic' => '천자문 입문',
+      _ => json['category'] as String? ?? '직접 추가',
+    };
+
     return WordCard(
       id: json['id'] as int,
       word: json['word'] as String,
       meaningKo: json['meaning_ko'] as String,
       exampleEn: json['example_en'] as String,
       exampleKo: json['example_ko'] as String,
-      level: json['level'] as String,
+      level: level,
       category: json['category'] as String,
+      deckId: json['deck_id'] as String? ?? defaultDeckId,
+      deckName: json['deck_name'] as String? ?? defaultDeckName,
     );
   }
 }

--- a/app/lib/screens/decks_screen.dart
+++ b/app/lib/screens/decks_screen.dart
@@ -1,18 +1,19 @@
 import 'package:flutter/material.dart';
 
+import '../models/deck_summary.dart';
 import '../widgets/review_note_card.dart';
 
 class DecksScreen extends StatelessWidget {
   const DecksScreen({
     super.key,
-    required this.totalCards,
-    required this.customCards,
-    required this.onStartToday,
+    required this.decks,
+    required this.selectedDeckId,
+    required this.onStudyDeck,
   });
 
-  final int totalCards;
-  final int customCards;
-  final VoidCallback onStartToday;
+  final List<DeckSummary> decks;
+  final String selectedDeckId;
+  final ValueChanged<String> onStudyDeck;
 
   @override
   Widget build(BuildContext context) {
@@ -27,26 +28,29 @@ class DecksScreen extends StatelessWidget {
               '실제 편집/중지는 다음 개발 반복에서 들어갑니다.',
         ),
         const SizedBox(height: 12),
-        Card(
-          child: ListTile(
-            leading: const Icon(Icons.menu_book),
-            title: const Text('중2 초급 영어 120'),
-            subtitle: Text('카드 $totalCards개 · 다음 복습: 오늘 · 상태: 진행 중'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => DeckDetailScreen(
-                  totalCards: totalCards,
-                  customCards: customCards,
-                  onStartToday: () {
-                    Navigator.of(context).pop();
-                    onStartToday();
-                  },
+        for (final deck in decks)
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.menu_book),
+              title: Text(deck.name),
+              subtitle: Text(
+                '카드 ${deck.totalCards}개 · 직접 추가 ${deck.customCards}개 · 상태: ${deck.id == selectedDeckId ? '선택됨' : '대기'}',
+              ),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => DeckDetailScreen(
+                    deck: deck,
+                    isSelected: deck.id == selectedDeckId,
+                    onStartToday: () {
+                      Navigator.of(context).pop();
+                      onStudyDeck(deck.id);
+                    },
+                  ),
                 ),
               ),
             ),
           ),
-        ),
       ],
     );
   }
@@ -55,13 +59,13 @@ class DecksScreen extends StatelessWidget {
 class DeckDetailScreen extends StatelessWidget {
   const DeckDetailScreen({
     super.key,
-    required this.totalCards,
-    required this.customCards,
+    required this.deck,
+    required this.isSelected,
     required this.onStartToday,
   });
 
-  final int totalCards;
-  final int customCards;
+  final DeckSummary deck;
+  final bool isSelected;
   final VoidCallback onStartToday;
 
   @override
@@ -71,23 +75,23 @@ class DeckDetailScreen extends StatelessWidget {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          Text('중2 초급 영어 120', style: Theme.of(context).textTheme.headlineSmall),
+          Text(deck.name, style: Theme.of(context).textTheme.headlineSmall),
           const SizedBox(height: 8),
           Text(
-            '오늘 복습 우선 덱 · 바로 Today로 돌아가 학습을 시작할 수 있습니다.',
+            '선택한 덱만 Today에서 바로 학습할 수 있습니다.',
             style: Theme.of(context).textTheme.bodyMedium,
           ),
           const SizedBox(height: 16),
           Card(
             child: ListTile(
               title: const Text('카드 수'),
-              subtitle: Text('$totalCards개'),
+              subtitle: Text('${deck.totalCards}개'),
             ),
           ),
           Card(
             child: ListTile(
               title: const Text('직접 추가 카드'),
-              subtitle: Text('$customCards개'),
+              subtitle: Text('${deck.customCards}개'),
             ),
           ),
           const Card(
@@ -103,10 +107,13 @@ class DeckDetailScreen extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 16),
+          if (isSelected)
+            const Chip(label: Text('현재 선택된 덱')),
+          const SizedBox(height: 8),
           FilledButton.icon(
             onPressed: onStartToday,
             icon: const Icon(Icons.play_arrow),
-            label: const Text('학습 시작'),
+            label: const Text('이 덱 학습'),
           ),
         ],
       ),

--- a/app/lib/screens/today_screen.dart
+++ b/app/lib/screens/today_screen.dart
@@ -7,10 +7,12 @@ class TodayScreen extends StatefulWidget {
   const TodayScreen({
     super.key,
     required this.cards,
+    required this.deckName,
     required this.onStatsChanged,
   });
 
   final List<WordCard> cards;
+  final String deckName;
   final ValueChanged<SessionStats> onStatsChanged;
 
   @override
@@ -120,7 +122,7 @@ class _TodayScreenState extends State<TodayScreen> {
                 children: [
                   Text('Today', style: Theme.of(context).textTheme.headlineMedium),
                   const SizedBox(height: 4),
-                  const Text('중2 초급 영어 · Iteration 1 리뷰 빌드'),
+                  Text('${widget.deckName} · Iteration 1 리뷰 빌드'),
                   const SizedBox(height: 8),
                   Text(
                     '리뷰 포인트: 3단계 평가와 짧은 세션 흐름',

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -11,6 +11,7 @@ void main() {
     expect(find.text('Today'), findsWidgets);
     expect(find.text('Decks'), findsOneWidget);
     expect(find.text('Insights'), findsOneWidget);
+    expect(find.text('중2 초급 영어 · Iteration 1 리뷰 빌드'), findsOneWidget);
   });
 
   testWidgets('Advances card on Again button tap', (WidgetTester tester) async {
@@ -129,7 +130,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Decks'), findsWidgets);
-    expect(find.text('중2 초급 영어 120'), findsOneWidget);
+    expect(find.text('중2 초급 영어'), findsOneWidget);
   });
 
   testWidgets('Insights shows recent change and next review cards', (WidgetTester tester) async {
@@ -176,7 +177,7 @@ void main() {
 
     await tester.tap(find.text('Decks').last);
     await tester.pumpAndSettle();
-    expect(find.textContaining('카드 121개'), findsOneWidget);
+    expect(find.text('여행 영어'), findsOneWidget);
   });
 
   testWidgets('Deck detail can start Today and reflects custom card count', (WidgetTester tester) async {
@@ -195,17 +196,36 @@ void main() {
 
     await tester.tap(find.text('Decks').last);
     await tester.pumpAndSettle();
-    await tester.tap(find.text('중2 초급 영어 120'));
+    await tester.tap(find.text('중2 초급 영어'));
     await tester.pumpAndSettle();
 
     expect(find.text('Deck Detail'), findsOneWidget);
-    expect(find.text('121개'), findsOneWidget);
-    expect(find.text('1개'), findsOneWidget);
+    expect(find.text('120개'), findsOneWidget);
+    expect(find.text('0개'), findsOneWidget);
 
-    await tester.tap(find.text('학습 시작'));
+    await tester.tap(find.text('이 덱 학습'));
     await tester.pumpAndSettle();
 
     expect(find.textContaining('진행: 0 /'), findsOneWidget);
+  });
+
+  testWidgets('Decks shows Cheonjamun sample deck and can study it', (WidgetTester tester) async {
+    await tester.pumpWidget(const RepeatoApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Decks').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('중2 초급 영어'), findsOneWidget);
+    expect(find.text('천자문 입문'), findsOneWidget);
+
+    await tester.tap(find.text('천자문 입문'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('이 덱 학습'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('천자문 입문 · Iteration 1 리뷰 빌드'), findsOneWidget);
+    expect(find.text('天'), findsOneWidget);
   });
 
   testWidgets('Insights action can move back to Today with KPI cards visible', (WidgetTester tester) async {


### PR DESCRIPTION
## 연결 이슈
- Closes #17

## 요약
- `천자문 입문` 샘플 덱(8카드)을 추가했습니다
- 다중 덱 로딩 구조를 도입하고 영어/천자문 덱을 동시에 불러옵니다
- `Decks` 목록에 여러 덱을 노출하고, 상세에서 `이 덱 학습`으로 선택 덱을 시작할 수 있게 했습니다
- `Today`는 선택한 덱 카드만 학습하도록 연결했습니다

## 논의 참여
- User Representative
- PM
- UX Developer
- App Developer
- Learning Specialist
- QA Engineer

## 테스트
- [x] `flutter analyze`
- [x] `flutter test --coverage`
- [x] coverage >= 70%
- [ ] manual QA

## 커버리지
- 현재 line coverage: `92.10%`

## QA 포인트
- 영어/천자문 덱 동시 노출
- `천자문 입문` 선택 후 `Today`에서 한자 카드 학습 시작
- 기존 영어 덱 학습/Deck 상세 흐름 회귀 여부

## PM 의사결정 필요 항목
- 없음