### PR TITLE
다중 덱 오늘 학습 상태를 Insights와 Add에 반영 3차

### DIFF
--- a/app/lib/app_root.dart
+++ b/app/lib/app_root.dart
@@ -191,6 +191,7 @@ class _AppRootState extends State<AppRoot> {
     }
     final todayDecks = decks.where((deck) => _todayStudyDeckIds.contains(deck.id)).toList();
     final todayDeckLabel = todayDecks.map((deck) => deck.name).join(' + ');
+    final todayDeckNames = todayDecks.map((deck) => deck.name).toList();
     final todayCards = _cards.where((card) => _todayStudyDeckIds.contains(card.deckId)).toList();
     final screens = <Widget>[
       TodayScreen(
@@ -209,11 +210,13 @@ class _AppRootState extends State<AppRoot> {
         key: const ValueKey('add-screen'),
         onAddCard: _addCard,
         onNavigateToday: () => setState(() => _currentIndex = 0),
+        todayStudyDeckNames: todayDeckNames,
       ),
       InsightsScreen(
         stats: _stats,
         deckName: todayDeckLabel,
         totalCards: todayCards.length,
+        todayStudyDeckNames: todayDeckNames,
         onStartToday: () => setState(() => _currentIndex = 0),
         onOpenDeck: () => setState(() => _currentIndex = 1),
       ),

--- a/app/lib/screens/add_screen.dart
+++ b/app/lib/screens/add_screen.dart
@@ -7,6 +7,7 @@ class AddScreen extends StatefulWidget {
     super.key,
     required this.onAddCard,
     required this.onNavigateToday,
+    required this.todayStudyDeckNames,
   });
 
   final void Function({
@@ -16,6 +17,7 @@ class AddScreen extends StatefulWidget {
     required bool moveToToday,
   }) onAddCard;
   final VoidCallback onNavigateToday;
+  final List<String> todayStudyDeckNames;
 
   @override
   State<AddScreen> createState() => _AddScreenState();
@@ -66,7 +68,27 @@ class _AddScreenState extends State<AddScreen> {
   }
 
   @override
+  void didUpdateWidget(covariant AddScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.todayStudyDeckNames.isEmpty) {
+      return;
+    }
+
+    final currentDeck = _deckController.text.trim();
+    if (currentDeck.isEmpty || currentDeck == '직접 추가' || !widget.todayStudyDeckNames.contains(currentDeck)) {
+      _deckController.text = widget.todayStudyDeckNames.first;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    if (widget.todayStudyDeckNames.isNotEmpty &&
+        (_deckController.text.trim().isEmpty ||
+            _deckController.text.trim() == '직접 추가' ||
+            !widget.todayStudyDeckNames.contains(_deckController.text.trim()))) {
+      _deckController.text = widget.todayStudyDeckNames.first;
+    }
+
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -74,7 +96,41 @@ class _AddScreenState extends State<AddScreen> {
         const SizedBox(height: 12),
         const ReviewNoteCard(
           title: '리뷰 설명',
-          body: '사용자 그룹에는 "직접 입력 후 Today로 복귀하는 흐름이 자연스러운지"를 확인해 달라고 안내합니다.',
+          body: '사용자 그룹에는 "오늘 학습 중인 덱 맥락이 Add에서도 자연스럽게 이어지는지"를 확인해 달라고 안내합니다.',
+        ),
+        const SizedBox(height: 12),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('오늘 학습 덱', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                Text(
+                  widget.todayStudyDeckNames.isEmpty
+                      ? '활성화된 오늘 학습 덱이 없습니다.'
+                      : '현재 ${widget.todayStudyDeckNames.length}개 덱이 오늘 학습에 포함돼 있습니다.',
+                ),
+                if (widget.todayStudyDeckNames.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: widget.todayStudyDeckNames
+                        .map(
+                          (deckName) => ChoiceChip(
+                            label: Text(deckName),
+                            selected: _deckController.text.trim() == deckName,
+                            onSelected: (_) => setState(() => _deckController.text = deckName),
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ],
+              ],
+            ),
+          ),
         ),
         if (_lastSavedWord != null) ...[
           const SizedBox(height: 12),

--- a/app/lib/screens/insights_screen.dart
+++ b/app/lib/screens/insights_screen.dart
@@ -9,6 +9,7 @@ class InsightsScreen extends StatelessWidget {
     required this.stats,
     required this.deckName,
     required this.totalCards,
+    required this.todayStudyDeckNames,
     required this.onStartToday,
     required this.onOpenDeck,
   });
@@ -16,6 +17,7 @@ class InsightsScreen extends StatelessWidget {
   final SessionStats stats;
   final String deckName;
   final int totalCards;
+  final List<String> todayStudyDeckNames;
   final VoidCallback onStartToday;
   final VoidCallback onOpenDeck;
 
@@ -43,6 +45,9 @@ class InsightsScreen extends StatelessWidget {
         : solved == 0
             ? '아직 시작 전'
             : '진행 중';
+    final todayDeckSummary = todayStudyDeckNames.length <= 2
+        ? todayStudyDeckNames.join(' + ')
+        : '${todayStudyDeckNames.take(2).join(', ')} 외 ${todayStudyDeckNames.length - 2}개';
 
     return ListView(
       padding: const EdgeInsets.all(16),
@@ -53,6 +58,30 @@ class InsightsScreen extends StatelessWidget {
           title: '리뷰 설명',
           body: '이번 반복에서는 현재 학습 중인 덱의 전체 진행 감각과 오늘 남은 양을 먼저 보이게 합니다. '
               '주간/월간 추이와 장기 지표는 이벤트 스키마 확정 후 확장합니다.',
+        ),
+        const SizedBox(height: 12),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('오늘 학습 덱', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                Text(
+                  '오늘 학습 덱 ${todayStudyDeckNames.length}개',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 6),
+                Text(todayDeckSummary, style: Theme.of(context).textTheme.bodyMedium),
+                const SizedBox(height: 12),
+                Text(
+                  '아래 진행률과 남은 카드는 선택된 오늘 학습 덱 전체를 합산한 기준입니다.',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
         ),
         const SizedBox(height: 12),
         Card(

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -89,17 +89,26 @@ void main() {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
+    await tester.tap(find.text('Decks').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(Switch).last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Today').last);
+    await tester.pumpAndSettle();
+
     await tester.tap(find.text('알겠음').first);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Insights').last);
     await tester.pumpAndSettle();
 
+    expect(find.text('오늘 학습 덱'), findsOneWidget);
+    expect(find.text('오늘 학습 덱 2개'), findsOneWidget);
+    expect(find.text('중2 초급 영어 + 천자문 입문'), findsWidgets);
     expect(find.text('현재 학습 중인 덱'), findsOneWidget);
-    expect(find.text('중2 초급 영어'), findsOneWidget);
     expect(find.text('덱 전체 진행률'), findsOneWidget);
     expect(find.text('오늘 남은 카드'), findsOneWidget);
-    expect(find.text('1 / 120 경험'), findsOneWidget);
+    expect(find.text('1 / 128 경험'), findsOneWidget);
     expect(find.text('29장'), findsOneWidget);
   });
 
@@ -112,7 +121,11 @@ void main() {
     await tester.tap(find.text('Insights').last);
     await tester.pumpAndSettle();
 
-    await tester.drag(find.byType(Scrollable).last, const Offset(0, -400));
+    await tester.scrollUntilVisible(
+      find.text('약점 영역 요약'),
+      160,
+      scrollable: find.byType(Scrollable).last,
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('약점 영역 요약'), findsOneWidget);
@@ -155,10 +168,28 @@ void main() {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
+    await tester.tap(find.text('Decks').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(Switch).last);
+    await tester.pumpAndSettle();
+
     await tester.tap(find.text('Add').last);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('카드 저장'));
+    expect(find.text('오늘 학습 덱'), findsOneWidget);
+    expect(find.text('현재 2개 덱이 오늘 학습에 포함돼 있습니다.'), findsOneWidget);
+    expect(find.widgetWithText(ChoiceChip, '중2 초급 영어'), findsOneWidget);
+    expect(find.widgetWithText(ChoiceChip, '천자문 입문'), findsOneWidget);
+
+    final saveButton = find.widgetWithText(FilledButton, '카드 저장');
+    await tester.scrollUntilVisible(
+      saveButton,
+      160,
+      scrollable: find.byType(Scrollable).last,
+    );
+    final savePressed = tester.widget<FilledButton>(saveButton).onPressed;
+    expect(savePressed, isNotNull);
+    savePressed!();
     await tester.pumpAndSettle();
     expect(find.text('앞면을 입력해 주세요.'), findsOneWidget);
     expect(find.text('뒷면을 입력해 주세요.'), findsOneWidget);
@@ -166,8 +197,18 @@ void main() {
     final fields = find.byType(TextFormField);
     await tester.enterText(fields.at(0), 'resilient');
     await tester.enterText(fields.at(1), '회복력이 있는');
-    await tester.enterText(fields.at(2), '여행 영어');
-    await tester.tap(find.text('카드 저장'));
+    await tester.tap(find.widgetWithText(ChoiceChip, '천자문 입문'));
+    await tester.pumpAndSettle();
+    tester.testTextInput.hide();
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      saveButton,
+      160,
+      scrollable: find.byType(Scrollable).last,
+    );
+    final savePressedAfterInput = tester.widget<FilledButton>(saveButton).onPressed;
+    expect(savePressedAfterInput, isNotNull);
+    savePressedAfterInput!();
     await tester.pumpAndSettle();
 
     expect(find.textContaining('저장 완료'), findsOneWidget);
@@ -177,7 +218,7 @@ void main() {
 
     await tester.tap(find.text('Decks').last);
     await tester.pumpAndSettle();
-    expect(find.text('여행 영어'), findsOneWidget);
+    expect(find.text('천자문 입문'), findsWidgets);
   });
 
   testWidgets('Deck detail can start Today and reflects custom card count', (WidgetTester tester) async {
@@ -191,7 +232,17 @@ void main() {
     await tester.enterText(fields.at(0), 'portable');
     await tester.enterText(fields.at(1), '휴대용의');
     await tester.enterText(fields.at(2), '여행 영어');
-    await tester.tap(find.text('카드 저장'));
+    final saveButton = find.widgetWithText(FilledButton, '카드 저장');
+    tester.testTextInput.hide();
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      saveButton,
+      160,
+      scrollable: find.byType(Scrollable).last,
+    );
+    final savePressed = tester.widget<FilledButton>(saveButton).onPressed;
+    expect(savePressed, isNotNull);
+    savePressed!();
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Decks').last);
@@ -269,7 +320,14 @@ void main() {
     );
     final retryButton = find.widgetWithText(FilledButton, '약점 다시 학습');
     expect(retryButton, findsOneWidget);
-    await tester.tap(retryButton);
+    await tester.scrollUntilVisible(
+      retryButton,
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    final retryPressed = tester.widget<FilledButton>(retryButton).onPressed;
+    expect(retryPressed, isNotNull);
+    retryPressed!();
     await tester.pumpAndSettle();
 
     expect(find.textContaining('진행: 1 /'), findsOneWidget);

--- a/doc/context-inbox.md
+++ b/doc/context-inbox.md
@@ -17,17 +17,18 @@
 
 ## Active
 - 날짜: 2026-03-15
-- 작업 주제: Insights 최근 변화와 다음 복습 시점 카드 구현
+- 작업 주제: 다중 덱 Today 상태를 Insights와 Add에 반영 3차
 - 임시 컨텍스트:
-  - GitHub 이슈 `#15 Insights 최근 변화와 다음 복습 시점 카드 추가` 생성 완료
-  - 작업 브랜치 `feat/15-insights-trend-next-review` 생성 완료
-  - `Insights`에 `최근 변화` 카드 추가
-  - `Insights`에 `다음 복습 시점` 카드 추가
+  - GitHub 이슈 `#21 다중 덱 오늘 학습 상태를 Insights와 Add에 반영 3차` 생성 완료
+  - 작업 브랜치 `feat/21-multi-deck-insights-add` 생성 완료
+  - `Insights`에 `오늘 학습 덱 N개` 요약과 합산 기준 문구 추가
+  - `Add`에 오늘 학습 덱 안내 카드와 선택 칩 추가
+  - 다중 덱 시나리오 위젯 테스트 추가/보정
   - 현재 로컬 세션 기준 해석 문구와 예상 복습 문구를 노출
   - `flutter analyze` 통과
-  - `flutter test --coverage` 통과, line coverage 92.03%
+  - `flutter test --coverage` 통과, line coverage 92.14%
 - 검증 필요:
-  - 장기 이벤트 스키마 없이 최근 변화/다음 복습을 어디까지 추정치로 허용할지
-  - 이후 `Insights` 차트형 확장을 언제 시작할지
+  - 오늘 학습 덱 추천에서 최근 입력 히스토리까지 확장할지
+  - 다중 덱 상태를 Profile에도 더 명시적으로 노출할지
 - 메모:
-  - 현재 최근 변화/다음 복습 시점은 장기 히스토리가 아니라 현재 세션 기준 해석 문구를 사용함
+  - 현재 Add는 오늘 학습 덱 선택 칩을 제공하지만 자동 추천 로직/영속 저장은 아직 없다

--- a/doc/context-log.md
+++ b/doc/context-log.md
@@ -10,6 +10,18 @@
 ---
 
 ## Entries
+- 날짜: 2026-03-15
+- 결정: 하루 학습은 단일 덱이 아니라 여러 덱을 함께 담는 `todayStudyDeckIds` 구조로 운영하고, 이를 `Today -> Insights -> Add`에 일관되게 반영한다.
+- 근거: 사용자가 하루 학습을 여러 덱으로 구성하는 실제 사용 맥락을 명시했고, Today만 다중 덱을 지원하면 다른 탭에서 현재 학습 맥락이 끊기기 때문이다.
+- 영향 범위: `app/lib/app_root.dart`, `app/lib/screens/decks_screen.dart`, `app/lib/screens/today_screen.dart`, `app/lib/screens/insights_screen.dart`, `app/lib/screens/add_screen.dart`, `app/test/widget_test.dart`, GitHub 이슈 `#19`, `#21`, 관련 협의 문서 2종.
+- 후속 작업: `Profile`의 다중 덱 표시 강화, `Add` 입력 히스토리/최근 덱 제안, 이벤트 스키마 정의.
+
+- 날짜: 2026-03-15
+- 결정: 다중 덱 교차 탭 정합성 3차 구현의 검증 기준은 `flutter analyze` 통과, `flutter test --coverage` 통과, line coverage `92.14%`로 기록한다.
+- 근거: 개발 조직 품질 기준으로 70% 이상 커버리지를 유지해야 하며, 이번 반복은 다중 덱 회귀 테스트가 추가된 교차 탭 변경이기 때문이다.
+- 영향 범위: GitHub 이슈 `#21`, PR 본문 검증 섹션, QA 게이트 보고 포맷.
+- 후속 작업: 다음 개발 이슈에서도 동일 포맷으로 커버리지 수치를 누적한다.
+
 - 날짜: 2026-02-22
 - 결정: 중2 초급 영어 초기버전(v1)은 PDF 기반 120단어 데이터셋으로 Today 학습 루프가 동작하는 5탭 앱으로 구현한다.
 - 근거: 사용자 요청의 1차 타깃(중2 초급)과 즉시 학습 시작 요구를 가장 빠르게 검증할 수 있는 범위이기 때문.

--- a/doc/next-actions.md
+++ b/doc/next-actions.md
@@ -3,7 +3,7 @@
 ## Priority Queue
 1. [ ] (P1) `#STAGE-C #TASK-DATA #TASK-TAB #ORG-PM #ORG-DATA #ORG-ARCH` `Insights` 차트형 확장 전 이벤트 스키마(`deck_progress`, `weak_area_summary`, `trend_delta`, `next_due_bucket`) 정의
 2. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` `Add` 2차 반복: 입력 히스토리/최근 덱 제안/저장 후 재입력 흐름 고도화
-3. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-ARCH #ORG-QA` `Add` 2차 반복: 입력 히스토리/최근 덱 제안/저장 후 재입력 흐름 고도화
+3. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DESIGN #ORG-QA` `Profile`에 다중 덱 Today 상태와 목표/신뢰 요약 연결 강화
 4. [ ] (P1) `#STAGE-D #TASK-TAB #TASK-APP #ORG-FE #ORG-DESIGN #ORG-QA` `Profile` 2차 반복: 목표 카드 수 설정과 전역 상태 키 연결 검토
 5. [ ] (P1) `#STAGE-C #TASK-DATA #TASK-APP #ORG-ARCH #ORG-DATA #ORG-FE` Flutter 로컬 SQLite 저장 계층과 도메인 모델 설계안을 코드 구조로 내리기 (`doc/work/repeato-local-first-architecture-v1.md`)
 5. [ ] (P1) `#STAGE-C #TASK-WORKFLOW #ORG-WF-ARCH #ORG-WF-LIB #ORG-WF-AUTO #ORG-PM` workflow 조직 세션 기준 문서 유지 및 coverage 70% 운영 규칙을 다음 개발 이슈/PR에 계속 적용
@@ -19,6 +19,12 @@
 ## Done in This Iteration
 - `Insights`에 `최근 변화` 카드 추가
 - `Insights`에 `다음 복습 시점` 카드 추가
+- 다중 덱 Today 큐 구조 도입
+- `Insights`에 `오늘 학습 덱 N개` 요약과 합산 기준 문구 추가
+- `Add`에 오늘 학습 덱 안내 카드와 선택 칩 추가
+- `flutter analyze` 통과
+- `flutter test --coverage` 통과
+- 라인 커버리지 `92.14%` 확인
 - `flutter analyze` 통과
 - `flutter test --coverage` 통과
 - 라인 커버리지 `92.03%` 확인

--- a/doc/project-context.md
+++ b/doc/project-context.md
@@ -173,3 +173,11 @@
 30. `doc/work/repeato-insights-user-needs-review-2026-03-15-v1.md`
 - 설명: `Insights`에서 사용자가 실제로 보고 싶어하는 항목에 대한 3차 회의체 재검토 문서
 - 사용 시점: `Insights` KPI 우선순위 재정의, 덱 전체 진행률/오늘 잔량/약점 요약 구현 범위 확정 시
+
+31. `doc/work/repeato-multi-deck-daily-study-review-2026-03-15-v1.md`
+- 설명: 하루 학습을 여러 덱으로 운영하는 방향에 대한 재협의 및 2차 구현 기준 문서
+- 사용 시점: 단일 덱 Today 구조를 다중 덱 Today 큐 구조로 전환할 때
+
+32. `doc/work/repeato-multi-deck-cross-tab-alignment-2026-03-15-v1.md`
+- 설명: 다중 덱 Today 상태를 `Insights`와 `Add`까지 일관되게 확장하기 위한 3차 협의 문서
+- 사용 시점: 다중 덱 상태를 교차 탭으로 반영할 때

--- a/doc/work/index.md
+++ b/doc/work/index.md
@@ -149,3 +149,13 @@
 - 설명: `Insights`에서 사용자가 실제로 보고 싶어하는 항목에 대한 3차 회의체 재검토 문서
 - 상태: Active
 - 사용 시점: `Insights` KPI 우선순위 재정의, 덱 전체 진행률/오늘 잔량/약점 요약 구현 범위 확정 시
+
+30. `doc/work/repeato-multi-deck-daily-study-review-2026-03-15-v1.md`
+- 설명: 하루 학습을 여러 덱으로 운영하는 방향에 대한 재협의 및 2차 구현 기준 문서
+- 상태: Active
+- 사용 시점: 단일 덱 Today 구조를 다중 덱 Today 큐 구조로 전환할 때
+
+31. `doc/work/repeato-multi-deck-cross-tab-alignment-2026-03-15-v1.md`
+- 설명: 다중 덱 Today 상태를 `Insights`와 `Add`까지 일관되게 확장하기 위한 3차 협의 문서
+- 상태: Active
+- 사용 시점: 다중 덱 상태를 교차 탭으로 반영할 때

--- a/doc/work/repeato-multi-deck-cross-tab-alignment-2026-03-15-v1.md
+++ b/doc/work/repeato-multi-deck-cross-tab-alignment-2026-03-15-v1.md
@@ -1,0 +1,32 @@
+# Repeato Multi-Deck Cross-Tab Alignment Review v1
+
+- 날짜: 2026-03-15
+- 범위: 하루 다중 덱 학습 3차 반복
+- 태그: `#STAGE-B` `#TASK-TAB` `#TASK-APP` `#ORG-PM` `#ORG-DESIGN` `#ORG-FE` `#ORG-QA` `#ORG-EDU`
+
+## Round 1
+- User Representative: 다중 덱이 Today에만 보이면 맥락이 끊긴다. `Insights`와 `Add`에서도 현재 오늘 학습 덱을 보여야 한다.
+- PM: 이번 반복은 다중 덱 상태의 교차 탭 일관성 확보에 집중한다.
+- Product Designer: 덱 이름 전체 나열보다 `오늘 학습 덱 N개` 요약과 빠른 선택 칩이 읽기 쉽다.
+- App Developer: `AppRoot`에서 이미 상태를 관리하므로 props 확장으로 해결 가능하다.
+- Learning Specialist: 새 카드 입력도 현재 학습 중인 덱과 연결돼야 학습 연속성이 생긴다.
+- QA Engineer: 다중 덱 선택 후 `Insights`와 `Add`가 함께 바뀌는 경로를 검증해야 한다.
+
+## Round 2
+- PM: `Insights`는 합산 기준임을 명시해야 오해가 없다.
+- UX Developer: `Add`는 자유 입력을 유지하되 현재 오늘 학습 덱을 빠르게 선택할 수 있어야 한다.
+- App Developer: 기본 덱 입력값은 현재 오늘 학습 덱 첫 항목으로 유지하고, 칩 선택으로 즉시 전환한다.
+- QA Engineer: `Add` 저장 이후 기존 저장 CTA 회귀를 같이 확인한다.
+
+## Round 3
+- PM: 범위를 `Insights` 다중 덱 요약 + `Add` 오늘 학습 덱 추천으로 확정한다.
+- Product Designer: 덱 수 요약, 대표 덱명, 합산 기준 안내 문구를 확정한다.
+- Learning Specialist: 현재 학습 중인 덱으로 카드 추가를 유도하는 흐름을 승인한다.
+- QA Engineer: 다중 덱 시나리오 위젯 테스트 추가와 coverage 70% 이상 유지 기준을 승인한다.
+
+## Final Decisions
+- `Insights`는 `오늘 학습 덱 N개`와 대표 덱명 요약을 노출한다.
+- `Insights`의 진행률/남은 카드/통계는 선택된 Today 덱의 합산 기준으로 해석한다.
+- `Add`는 오늘 학습 덱 요약 카드와 선택 칩을 제공한다.
+- `Add` 기본 덱 입력값은 현재 오늘 학습 덱 첫 항목을 사용한다.
+- 영속 저장소, 덱별 분리 통계, 자동 추천 로직은 이후 작업으로 보류한다.


### PR DESCRIPTION
## 요약
하루 다중 덱 학습 상태를 `Insights`와 `Add`까지 확장해 현재 오늘 학습 맥락이 탭 전반에 일관되게 보이도록 정리했습니다.

## 반영 내용
- `Insights`에 `오늘 학습 덱 N개` 요약 카드 추가
- 다중 덱 합산 기준 안내 문구 추가
- `Add`에 오늘 학습 덱 안내 카드와 선택 칩 추가
- 기본 덱 입력값을 현재 오늘 학습 덱으로 정렬
- 다중 덱 시나리오 위젯 테스트 보강
- 협의 문서/컨텍스트 로그 갱신

## Agent 협의
- User Representative
- PM
- Product Designer
- UX Developer
- App Developer
- Learning Specialist
- QA Engineer
- Workflow Enablement Group

## 검증
- `flutter analyze`
- `flutter test --coverage`
- line coverage `92.14%`

## 제외 범위
- 영속 저장
- 덱별 분리 통계
- 최근 입력 히스토리/자동 추천

## 다음 단계
- `Profile` 다중 덱 정합성 강화 또는 `Add` 입력 히스토리/최근 덱 제안