### PR TITLE
[codex] Add tab recent history and deck suggestions

### DIFF
--- a/app/lib/app_root.dart
+++ b/app/lib/app_root.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'models/add_history_entry.dart';
 import 'models/session_stats.dart';
 import 'models/deck_summary.dart';
 import 'models/word_card.dart';
@@ -24,6 +25,7 @@ class _AppRootState extends State<AppRoot> {
   int _currentIndex = 0;
   SessionStats _stats = SessionStats.empty;
   final List<WordCard> _cards = [];
+  final List<AddHistoryEntry> _recentAddHistory = [];
   final Set<String> _todayStudyDeckIds = {'m2_beginner_english'};
   bool _isLoading = true;
   Object? _loadError;
@@ -43,7 +45,14 @@ class _AppRootState extends State<AppRoot> {
           ..clear()
           ..addAll(cards);
         _isLoading = false;
-        _stats = SessionStats(target: 30, completed: 0, known: 0, unsure: 0, again: 0, done: false);
+        _stats = SessionStats(
+          target: 30,
+          completed: 0,
+          known: 0,
+          unsure: 0,
+          again: 0,
+          done: false,
+        );
       });
     } catch (error) {
       if (!mounted) return;
@@ -66,13 +75,18 @@ class _AppRootState extends State<AppRoot> {
         debugPrint('[Repeato] loadCards: start ($assetPath)');
         final raw = await rootBundle
             .loadString(assetPath)
-            .timeout(const Duration(seconds: 5), onTimeout: () {
-          throw TimeoutException('Timed out loading asset: $assetPath');
-        });
+            .timeout(
+              const Duration(seconds: 5),
+              onTimeout: () {
+                throw TimeoutException('Timed out loading asset: $assetPath');
+              },
+            );
         debugPrint('[Repeato] loadCards: loaded raw (${raw.length} chars)');
 
         final List<dynamic> decoded = jsonDecode(raw) as List<dynamic>;
-        debugPrint('[Repeato] loadCards: decoded list (${decoded.length} items)');
+        debugPrint(
+          '[Repeato] loadCards: decoded list (${decoded.length} items)',
+        );
 
         cards.addAll(
           decoded.map((e) => WordCard.fromJson(e as Map<String, dynamic>)),
@@ -93,7 +107,9 @@ class _AppRootState extends State<AppRoot> {
     required String deck,
     required bool moveToToday,
   }) {
-    final nextId = _cards.isEmpty ? 1 : _cards.map((card) => card.id).reduce((a, b) => a > b ? a : b) + 1;
+    final nextId = _cards.isEmpty
+        ? 1
+        : _cards.map((card) => card.id).reduce((a, b) => a > b ? a : b) + 1;
     final newCard = WordCard(
       id: nextId,
       word: word,
@@ -108,6 +124,13 @@ class _AppRootState extends State<AppRoot> {
 
     setState(() {
       _cards.add(newCard);
+      _recentAddHistory.insert(
+        0,
+        AddHistoryEntry(word: word, meaningKo: meaningKo, deckName: deck),
+      );
+      if (_recentAddHistory.length > 4) {
+        _recentAddHistory.removeRange(4, _recentAddHistory.length);
+      }
       if (moveToToday) {
         _currentIndex = 0;
       }
@@ -120,18 +143,23 @@ class _AppRootState extends State<AppRoot> {
       grouped.putIfAbsent(card.deckId, () => []).add(card);
     }
 
-    final decks = grouped.entries
-        .map(
-          (entry) => DeckSummary(
-            id: entry.key,
-            name: entry.value.first.deckName,
-            totalCards: entry.value.length,
-            customCards: entry.value.where((card) => card.level == 'custom').length,
-            isRecommendedToday: entry.key == 'm2_beginner_english' || entry.key == 'cheonjamun_basic',
-          ),
-        )
-        .toList()
-      ..sort((a, b) => a.name.compareTo(b.name));
+    final decks =
+        grouped.entries
+            .map(
+              (entry) => DeckSummary(
+                id: entry.key,
+                name: entry.value.first.deckName,
+                totalCards: entry.value.length,
+                customCards: entry.value
+                    .where((card) => card.level == 'custom')
+                    .length,
+                isRecommendedToday:
+                    entry.key == 'm2_beginner_english' ||
+                    entry.key == 'cheonjamun_basic',
+              ),
+            )
+            .toList()
+          ..sort((a, b) => a.name.compareTo(b.name));
     return decks;
   }
 
@@ -147,7 +175,8 @@ class _AppRootState extends State<AppRoot> {
 
   void _toggleTodayDeck(String deckId) {
     setState(() {
-      if (_todayStudyDeckIds.contains(deckId) && _todayStudyDeckIds.length > 1) {
+      if (_todayStudyDeckIds.contains(deckId) &&
+          _todayStudyDeckIds.length > 1) {
         _todayStudyDeckIds.remove(deckId);
       } else {
         _todayStudyDeckIds.add(deckId);
@@ -178,21 +207,25 @@ class _AppRootState extends State<AppRoot> {
     }
 
     if (_loadError != null) {
-      return Scaffold(
-        body: Center(
-          child: Text('데이터 로드 실패: $_loadError'),
-        ),
-      );
+      return Scaffold(body: Center(child: Text('데이터 로드 실패: $_loadError')));
     }
 
     final decks = _buildDecks();
     if (_todayStudyDeckIds.isEmpty && decks.isNotEmpty) {
       _todayStudyDeckIds.add(decks.first.id);
     }
-    final todayDecks = decks.where((deck) => _todayStudyDeckIds.contains(deck.id)).toList();
+    final todayDecks = decks
+        .where((deck) => _todayStudyDeckIds.contains(deck.id))
+        .toList();
     final todayDeckLabel = todayDecks.map((deck) => deck.name).join(' + ');
     final todayDeckNames = todayDecks.map((deck) => deck.name).toList();
-    final todayCards = _cards.where((card) => _todayStudyDeckIds.contains(card.deckId)).toList();
+    final recentDeckNames = <String>{
+      ..._recentAddHistory.map((entry) => entry.deckName),
+      ...decks.where((deck) => deck.customCards > 0).map((deck) => deck.name),
+    }.toList();
+    final todayCards = _cards
+        .where((card) => _todayStudyDeckIds.contains(card.deckId))
+        .toList();
     final screens = <Widget>[
       TodayScreen(
         key: ValueKey('today-${_todayStudyDeckIds.join('-')}'),
@@ -211,6 +244,8 @@ class _AppRootState extends State<AppRoot> {
         onAddCard: _addCard,
         onNavigateToday: () => setState(() => _currentIndex = 0),
         todayStudyDeckNames: todayDeckNames,
+        recentDeckNames: recentDeckNames,
+        recentEntries: _recentAddHistory,
       ),
       InsightsScreen(
         stats: _stats,
@@ -229,24 +264,37 @@ class _AppRootState extends State<AppRoot> {
 
     return Scaffold(
       body: SafeArea(
-        child: IndexedStack(
-          index: _currentIndex,
-          children: screens,
-        ),
+        child: IndexedStack(index: _currentIndex, children: screens),
       ),
       bottomNavigationBar: NavigationBar(
         selectedIndex: _currentIndex,
         onDestinationSelected: (i) => setState(() => _currentIndex = i),
         destinations: const [
-          NavigationDestination(icon: Icon(Icons.home_outlined), selectedIcon: Icon(Icons.home), label: 'Today'),
+          NavigationDestination(
+            icon: Icon(Icons.home_outlined),
+            selectedIcon: Icon(Icons.home),
+            label: 'Today',
+          ),
           NavigationDestination(
             icon: Icon(Icons.collections_bookmark_outlined),
             selectedIcon: Icon(Icons.collections_bookmark),
             label: 'Decks',
           ),
-          NavigationDestination(icon: Icon(Icons.add_circle_outline), selectedIcon: Icon(Icons.add_circle), label: 'Add'),
-          NavigationDestination(icon: Icon(Icons.bar_chart_outlined), selectedIcon: Icon(Icons.bar_chart), label: 'Insights'),
-          NavigationDestination(icon: Icon(Icons.person_outline), selectedIcon: Icon(Icons.person), label: 'Profile'),
+          NavigationDestination(
+            icon: Icon(Icons.add_circle_outline),
+            selectedIcon: Icon(Icons.add_circle),
+            label: 'Add',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.bar_chart_outlined),
+            selectedIcon: Icon(Icons.bar_chart),
+            label: 'Insights',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.person_outline),
+            selectedIcon: Icon(Icons.person),
+            label: 'Profile',
+          ),
         ],
       ),
     );

--- a/app/lib/models/add_history_entry.dart
+++ b/app/lib/models/add_history_entry.dart
@@ -1,0 +1,11 @@
+class AddHistoryEntry {
+  const AddHistoryEntry({
+    required this.word,
+    required this.meaningKo,
+    required this.deckName,
+  });
+
+  final String word;
+  final String meaningKo;
+  final String deckName;
+}

--- a/app/lib/screens/add_screen.dart
+++ b/app/lib/screens/add_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../models/add_history_entry.dart';
 import '../widgets/review_note_card.dart';
 
 class AddScreen extends StatefulWidget {
@@ -8,6 +9,8 @@ class AddScreen extends StatefulWidget {
     required this.onAddCard,
     required this.onNavigateToday,
     required this.todayStudyDeckNames,
+    required this.recentDeckNames,
+    required this.recentEntries,
   });
 
   final void Function({
@@ -15,9 +18,12 @@ class AddScreen extends StatefulWidget {
     required String meaningKo,
     required String deck,
     required bool moveToToday,
-  }) onAddCard;
+  })
+  onAddCard;
   final VoidCallback onNavigateToday;
   final List<String> todayStudyDeckNames;
+  final List<String> recentDeckNames;
+  final List<AddHistoryEntry> recentEntries;
 
   @override
   State<AddScreen> createState() => _AddScreenState();
@@ -28,6 +34,7 @@ class _AddScreenState extends State<AddScreen> {
   final _wordController = TextEditingController();
   final _meaningController = TextEditingController();
   final _deckController = TextEditingController(text: '직접 추가');
+  final _wordFocusNode = FocusNode();
   String? _lastSavedWord;
 
   @override
@@ -35,6 +42,7 @@ class _AddScreenState extends State<AddScreen> {
     _wordController.dispose();
     _meaningController.dispose();
     _deckController.dispose();
+    _wordFocusNode.dispose();
     super.dispose();
   }
 
@@ -61,10 +69,21 @@ class _AddScreenState extends State<AddScreen> {
       _wordController.clear();
       _meaningController.clear();
     });
+    _wordFocusNode.requestFocus();
 
     if (moveToToday) {
       widget.onNavigateToday();
     }
+  }
+
+  void _applyRecentEntry(AddHistoryEntry entry) {
+    setState(() {
+      _wordController.text = entry.word;
+      _meaningController.text = entry.meaningKo;
+      _deckController.text = entry.deckName;
+      _lastSavedWord = null;
+    });
+    _wordFocusNode.requestFocus();
   }
 
   @override
@@ -75,7 +94,7 @@ class _AddScreenState extends State<AddScreen> {
     }
 
     final currentDeck = _deckController.text.trim();
-    if (currentDeck.isEmpty || currentDeck == '직접 추가' || !widget.todayStudyDeckNames.contains(currentDeck)) {
+    if (currentDeck.isEmpty || currentDeck == '직접 추가') {
       _deckController.text = widget.todayStudyDeckNames.first;
     }
   }
@@ -84,8 +103,7 @@ class _AddScreenState extends State<AddScreen> {
   Widget build(BuildContext context) {
     if (widget.todayStudyDeckNames.isNotEmpty &&
         (_deckController.text.trim().isEmpty ||
-            _deckController.text.trim() == '직접 추가' ||
-            !widget.todayStudyDeckNames.contains(_deckController.text.trim()))) {
+            _deckController.text.trim() == '직접 추가')) {
       _deckController.text = widget.todayStudyDeckNames.first;
     }
 
@@ -122,7 +140,8 @@ class _AddScreenState extends State<AddScreen> {
                           (deckName) => ChoiceChip(
                             label: Text(deckName),
                             selected: _deckController.text.trim() == deckName,
-                            onSelected: (_) => setState(() => _deckController.text = deckName),
+                            onSelected: (_) =>
+                                setState(() => _deckController.text = deckName),
                           ),
                         )
                         .toList(),
@@ -132,6 +151,74 @@ class _AddScreenState extends State<AddScreen> {
             ),
           ),
         ),
+        if (widget.recentDeckNames.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '최근 사용 덱',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '방금 추가한 덱을 다시 선택해 입력 속도를 유지합니다.',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: widget.recentDeckNames
+                        .map(
+                          (deckName) => ChoiceChip(
+                            label: Text(deckName),
+                            selected: _deckController.text.trim() == deckName,
+                            onSelected: (_) =>
+                                setState(() => _deckController.text = deckName),
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+        if (widget.recentEntries.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('최근 입력', style: Theme.of(context).textTheme.titleMedium),
+                  const SizedBox(height: 8),
+                  Text(
+                    '직전 입력을 불러와 비슷한 카드를 빠르게 이어서 만들 수 있습니다.',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  for (final entry in widget.recentEntries)
+                    ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      leading: const Icon(Icons.history),
+                      title: Text(entry.word),
+                      subtitle: Text('${entry.meaningKo} · ${entry.deckName}'),
+                      trailing: TextButton(
+                        onPressed: () => _applyRecentEntry(entry),
+                        child: const Text('다시 입력'),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
         if (_lastSavedWord != null) ...[
           const SizedBox(height: 12),
           Card(
@@ -181,21 +268,29 @@ class _AddScreenState extends State<AddScreen> {
                 children: [
                   Row(
                     children: [
-                      Icon(Icons.edit_note, color: Theme.of(context).colorScheme.primary),
+                      Icon(
+                        Icons.edit_note,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
                       const SizedBox(width: 8),
-                      Text('직접 입력', style: Theme.of(context).textTheme.titleMedium),
+                      Text(
+                        '직접 입력',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
                     ],
                   ),
                   const SizedBox(height: 12),
                   TextFormField(
                     controller: _wordController,
+                    focusNode: _wordFocusNode,
                     decoration: const InputDecoration(
                       labelText: '앞면',
                       hintText: '예: resilient',
                       border: OutlineInputBorder(),
                     ),
-                    validator: (value) =>
-                        value == null || value.trim().isEmpty ? '앞면을 입력해 주세요.' : null,
+                    validator: (value) => value == null || value.trim().isEmpty
+                        ? '앞면을 입력해 주세요.'
+                        : null,
                   ),
                   const SizedBox(height: 12),
                   TextFormField(
@@ -205,8 +300,9 @@ class _AddScreenState extends State<AddScreen> {
                       hintText: '예: 회복력이 있는',
                       border: OutlineInputBorder(),
                     ),
-                    validator: (value) =>
-                        value == null || value.trim().isEmpty ? '뒷면을 입력해 주세요.' : null,
+                    validator: (value) => value == null || value.trim().isEmpty
+                        ? '뒷면을 입력해 주세요.'
+                        : null,
                   ),
                   const SizedBox(height: 12),
                   TextFormField(
@@ -216,8 +312,9 @@ class _AddScreenState extends State<AddScreen> {
                       hintText: '예: 여행 영어',
                       border: OutlineInputBorder(),
                     ),
-                    validator: (value) =>
-                        value == null || value.trim().isEmpty ? '덱 이름을 입력해 주세요.' : null,
+                    validator: (value) => value == null || value.trim().isEmpty
+                        ? '덱 이름을 입력해 주세요.'
+                        : null,
                   ),
                   const SizedBox(height: 12),
                   FilledButton.icon(

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -26,7 +26,9 @@ void main() {
     expect(find.textContaining('진행: 1 /'), findsOneWidget);
   });
 
-  testWidgets('Today session controls can reset progress and switch target', (WidgetTester tester) async {
+  testWidgets('Today session controls can reset progress and switch target', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
@@ -44,12 +46,15 @@ void main() {
     expect(find.textContaining('진행: 0 / 60'), findsOneWidget);
   });
 
-  testWidgets('Swipe gestures advance card (left=known, right=again)', (WidgetTester tester) async {
+  testWidgets('Swipe gestures advance card (left=known, right=again)', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
     final card = find.byWidgetPredicate(
-      (widget) => widget is GestureDetector && widget.onHorizontalDragStart != null,
+      (widget) =>
+          widget is GestureDetector && widget.onHorizontalDragStart != null,
     );
     expect(find.textContaining('진행: 0 /'), findsOneWidget);
 
@@ -61,7 +66,8 @@ void main() {
     // Right swipe => dont know
     await tester.drag(
       find.byWidgetPredicate(
-        (widget) => widget is GestureDetector && widget.onHorizontalDragStart != null,
+        (widget) =>
+            widget is GestureDetector && widget.onHorizontalDragStart != null,
       ),
       const Offset(220, 0),
     );
@@ -85,7 +91,9 @@ void main() {
     expect(find.textContaining('헷갈림 1건'), findsOneWidget);
   });
 
-  testWidgets('Insights shows current deck progress and remaining cards', (WidgetTester tester) async {
+  testWidgets('Insights shows current deck progress and remaining cards', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
@@ -112,7 +120,9 @@ void main() {
     expect(find.text('29장'), findsOneWidget);
   });
 
-  testWidgets('Insights weak summary can open Decks tab', (WidgetTester tester) async {
+  testWidgets('Insights weak summary can open Decks tab', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
@@ -146,7 +156,9 @@ void main() {
     expect(find.text('중2 초급 영어'), findsOneWidget);
   });
 
-  testWidgets('Insights shows recent change and next review cards', (WidgetTester tester) async {
+  testWidgets('Insights shows recent change and next review cards', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
@@ -164,7 +176,9 @@ void main() {
     expect(find.textContaining('예상:'), findsWidgets);
   });
 
-  testWidgets('Add tab validates, saves a card, and can move to Today', (WidgetTester tester) async {
+  testWidgets('Add tab validates, saves a card, and can move to Today', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
@@ -206,7 +220,9 @@ void main() {
       160,
       scrollable: find.byType(Scrollable).last,
     );
-    final savePressedAfterInput = tester.widget<FilledButton>(saveButton).onPressed;
+    final savePressedAfterInput = tester
+        .widget<FilledButton>(saveButton)
+        .onPressed;
     expect(savePressedAfterInput, isNotNull);
     savePressedAfterInput!();
     await tester.pumpAndSettle();
@@ -221,7 +237,9 @@ void main() {
     expect(find.text('천자문 입문'), findsWidgets);
   });
 
-  testWidgets('Deck detail can start Today and reflects custom card count', (WidgetTester tester) async {
+  testWidgets('Deck detail can start Today and reflects custom card count', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
@@ -260,7 +278,9 @@ void main() {
     expect(find.textContaining('진행: 0 /'), findsOneWidget);
   });
 
-  testWidgets('Decks shows Cheonjamun sample deck and can study it', (WidgetTester tester) async {
+  testWidgets('Decks shows Cheonjamun sample deck and can study it', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
@@ -279,7 +299,9 @@ void main() {
     expect(find.text('天'), findsOneWidget);
   });
 
-  testWidgets('Decks can include multiple decks in today study queue', (WidgetTester tester) async {
+  testWidgets('Decks can include multiple decks in today study queue', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
@@ -296,7 +318,9 @@ void main() {
     expect(find.text('중2 초급 영어 + 천자문 입문 · Iteration 1 리뷰 빌드'), findsOneWidget);
   });
 
-  testWidgets('Insights action can move back to Today with KPI cards visible', (WidgetTester tester) async {
+  testWidgets('Insights action can move back to Today with KPI cards visible', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
@@ -333,7 +357,9 @@ void main() {
     expect(find.textContaining('진행: 1 /'), findsOneWidget);
   });
 
-  testWidgets('Profile shows trust summary and can resume Today', (WidgetTester tester) async {
+  testWidgets('Profile shows trust summary and can resume Today', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const RepeatoApp());
     await tester.pumpAndSettle();
 
@@ -356,5 +382,68 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('진행: 1 /'), findsOneWidget);
+  });
+
+  testWidgets('Add shows recent decks and recent entries after save', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const RepeatoApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Add').last);
+    await tester.pumpAndSettle();
+
+    final fields = find.byType(TextFormField);
+    await tester.enterText(fields.at(0), 'portable');
+    await tester.enterText(fields.at(1), '휴대용의');
+    await tester.enterText(fields.at(2), '여행 영어');
+    tester.testTextInput.hide();
+    await tester.pumpAndSettle();
+
+    final saveButton = find.widgetWithText(FilledButton, '카드 저장');
+    await tester.scrollUntilVisible(
+      saveButton,
+      160,
+      scrollable: find.byType(Scrollable).last,
+    );
+    final savePressed = tester.widget<FilledButton>(saveButton).onPressed;
+    expect(savePressed, isNotNull);
+    savePressed!();
+    await tester.pumpAndSettle();
+
+    expect(find.text('최근 사용 덱'), findsOneWidget);
+    expect(find.widgetWithText(ChoiceChip, '여행 영어'), findsOneWidget);
+    expect(find.text('최근 입력'), findsOneWidget);
+    expect(find.text('휴대용의 · 여행 영어'), findsOneWidget);
+
+    final savedFields = find.byType(TextFormField);
+    expect(
+      tester.widget<TextFormField>(savedFields.at(0)).controller!.text,
+      isEmpty,
+    );
+    expect(
+      tester.widget<TextFormField>(savedFields.at(1)).controller!.text,
+      isEmpty,
+    );
+    expect(
+      tester.widget<TextFormField>(savedFields.at(2)).controller!.text,
+      '여행 영어',
+    );
+
+    await tester.tap(find.text('다시 입력').first);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<TextFormField>(savedFields.at(0)).controller!.text,
+      'portable',
+    );
+    expect(
+      tester.widget<TextFormField>(savedFields.at(1)).controller!.text,
+      '휴대용의',
+    );
+    expect(
+      tester.widget<TextFormField>(savedFields.at(2)).controller!.text,
+      '여행 영어',
+    );
   });
 }


### PR DESCRIPTION
## 연결 이슈
- Closes #23

## 변경 요약
- `Add` 탭에 최근 사용 덱 제안 카드와 최근 입력 재사용 UI를 추가했습니다.
- 저장 직후 앞면/뒷면은 비우고 마지막으로 사용한 덱은 유지하도록 흐름을 조정했습니다.
- 세션 메모리 기준 최근 입력 4건을 `AppRoot`에서 관리하도록 상태를 확장했습니다.
- 관련 widget test를 추가해 저장 후 재입력 흐름과 최근 입력 복원을 검증했습니다.

## 왜 바뀌었나
직접 입력 MVP 이후에도 같은 덱에 연속으로 카드를 넣거나 방금 넣은 카드를 기반으로 비슷한 카드를 다시 만드는 흐름이 느렸습니다. 이번 변경은 저장 계층을 늘리지 않고도 `Add` 탭의 반복 입력 마찰을 줄이는 데 집중합니다.

## 사용자 영향
- 같은 덱에 여러 카드를 연속으로 추가할 때 다시 입력해야 하는 정보가 줄어듭니다.
- 최근 입력을 불러와 유사 카드 작성 속도가 빨라집니다.
- 기존 `Today로 이동` 흐름과 입력 검증 에러 흐름은 유지됩니다.

## 테스트 결과
- `flutter analyze`
- `flutter test --coverage`

## 커버리지 결과
- line coverage `92.22%` (`593 / 643`)

## QA 확인 포인트
- 최근 사용 덱 추천과 오늘 학습 덱 선택 칩이 함께 보여도 선택 흐름이 자연스러운지
- 저장 후 앞면/뒷면은 비워지고 덱 선택은 유지되는지
- `다시 입력` CTA가 단어/뜻/덱을 모두 복원하는지
- 기존 `Today로 이동` CTA와 검증 에러 동작이 회귀하지 않았는지

## PM 의사결정 필요 항목
- 없음