### PR TITLE
[codex] Show Profile today deck summary

### DIFF
--- a/app/lib/app_root.dart
+++ b/app/lib/app_root.dart
@@ -258,6 +258,7 @@ class _AppRootState extends State<AppRoot> {
       ProfileScreen(
         stats: _stats,
         totalCards: todayCards.length,
+        todayStudyDeckNames: todayDeckNames,
         onResumeToday: () => setState(() => _currentIndex = 0),
       ),
     ];

--- a/app/lib/screens/profile_screen.dart
+++ b/app/lib/screens/profile_screen.dart
@@ -7,11 +7,13 @@ class ProfileScreen extends StatelessWidget {
     super.key,
     required this.stats,
     required this.totalCards,
+    required this.todayStudyDeckNames,
     required this.onResumeToday,
   });
 
   final SessionStats stats;
   final int totalCards;
+  final List<String> todayStudyDeckNames;
   final VoidCallback onResumeToday;
 
   @override
@@ -23,6 +25,11 @@ class ProfileScreen extends StatelessWidget {
         : stats.done
         ? '오늘 목표 달성'
         : '오늘 학습 진행 중';
+    final todayDeckSummary = todayStudyDeckNames.isEmpty
+        ? '선택된 덱 없음'
+        : todayStudyDeckNames.length <= 2
+        ? todayStudyDeckNames.join(' + ')
+        : '${todayStudyDeckNames.take(2).join(', ')} 외 ${todayStudyDeckNames.length - 2}개';
 
     return ListView(
       padding: const EdgeInsets.all(16),
@@ -37,6 +44,14 @@ class ProfileScreen extends StatelessWidget {
               '$statusText · ${stats.completed}/${stats.target} 진행 · 정답률 $accuracy%',
             ),
             trailing: Text('$totalCards장'),
+          ),
+        ),
+        Card(
+          child: ListTile(
+            leading: const Icon(Icons.collections_bookmark_outlined),
+            title: Text('오늘 학습 덱 ${todayStudyDeckNames.length}개'),
+            subtitle: Text(todayDeckSummary),
+            trailing: const Chip(label: Text('Today')),
           ),
         ),
         Card(

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -371,6 +371,8 @@ void main() {
 
     expect(find.text('오늘 학습 요약'), findsOneWidget);
     expect(find.textContaining('1/30 진행'), findsOneWidget);
+    expect(find.text('오늘 학습 덱 1개'), findsOneWidget);
+    expect(find.text('중2 초급 영어'), findsWidgets);
     expect(find.text('로컬 저장 상태'), findsOneWidget);
     expect(find.text('로컬 전용'), findsOneWidget);
     expect(find.text('Today 이어서 학습'), findsOneWidget);
@@ -382,6 +384,24 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('진행: 1 /'), findsOneWidget);
+  });
+
+  testWidgets('Profile reflects multiple today study decks', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const RepeatoApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Decks').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(Switch).last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Profile').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('오늘 학습 덱 2개'), findsOneWidget);
+    expect(find.text('중2 초급 영어 + 천자문 입문'), findsOneWidget);
   });
 
   testWidgets('Add shows recent decks and recent entries after save', (


### PR DESCRIPTION
## 연결 이슈
- Closes #29

## 변경 요약
- `Profile`에 오늘 학습 덱 수와 덱 이름 요약 카드를 추가했습니다.
- `AppRoot`에서 계산한 `todayStudyDeckNames`를 `ProfileScreen`에 전달하도록 연결했습니다.
- 단일 덱/다중 덱 Profile 표시를 widget test로 검증했습니다.

## 사용자 영향
- 사용자가 Profile에서도 현재 Today 학습 대상 덱을 확인할 수 있습니다.
- 다중 덱 학습 상태가 Today/Decks/Insights/Add에 이어 Profile에서도 끊기지 않습니다.

## 테스트 결과
- `flutter analyze`
- `flutter test --coverage`

## 커버리지 결과
- line coverage `91.72%` (`609 / 664`)

## QA 확인 포인트
- Profile에서 기본 상태는 `오늘 학습 덱 1개`와 `중2 초급 영어`로 표시되는지
- Decks에서 천자문을 Today에 추가하면 Profile에서 `오늘 학습 덱 2개`와 `중2 초급 영어 + 천자문 입문`이 표시되는지
- 기존 `Today 이어서 학습` CTA가 유지되는지

## PM 의사결정 필요 항목
- 없음